### PR TITLE
StackExchange nuget package Build Error

### DIFF
--- a/src/Esfa.Vacancy.Register.Api/Esfa.Vacancy.Register.Api.csproj
+++ b/src/Esfa.Vacancy.Register.Api/Esfa.Vacancy.Register.Api.csproj
@@ -124,8 +124,8 @@
       <HintPath>..\packages\SFA.DAS.NLog.Targets.Redis.1.0.0.26805\lib\net45\SFA.DAS.NLog.Targets.Redis.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="StackExchange.Redis, Version=1.2.4.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\StackExchange.Redis.1.2.4\lib\net46\StackExchange.Redis.dll</HintPath>
+    <Reference Include="StackExchange.Redis, Version=1.1.608.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\StackExchange.Redis.1.1.608\lib\net45\StackExchange.Redis.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="StructureMap, Version=4.5.0.0, Culture=neutral, processorArchitecture=MSIL">

--- a/src/Esfa.Vacancy.Register.Api/packages.config
+++ b/src/Esfa.Vacancy.Register.Api/packages.config
@@ -27,7 +27,7 @@
   <package id="NLog" version="4.4.11" targetFramework="net452" />
   <package id="SFA.DAS.NLog.Logger" version="1.0.0.26805" targetFramework="net452" />
   <package id="SFA.DAS.NLog.Targets.Redis" version="1.0.0.26805" targetFramework="net452" />
-  <package id="StackExchange.Redis" version="1.2.4" targetFramework="net452" requireReinstallation="true" />
+  <package id="StackExchange.Redis" version="1.1.608" targetFramework="net452" />
   <package id="StructureMap" version="4.5.0" targetFramework="net452" />
   <package id="StructureMap.MVC5" version="3.1.1.134" targetFramework="net452" />
   <package id="structuremap.web" version="4.0.0.315" targetFramework="net452" />


### PR DESCRIPTION
StackExchange nuget package was pulling the latest version which requires the whole project to target 4.6 on build server. Instead of updating projects to be 4.6 chnaged dependency to earlier version so it is .NET 4.5 compatible and buils on the build server without extra configuration.