### PR TITLE
Ensure swagger resources are loaded over https to prevent mixed content error in webpage console

### DIFF
--- a/src/Esfa.Vacancy.Register.Api/App_Start/SwaggerConfig.cs
+++ b/src/Esfa.Vacancy.Register.Api/App_Start/SwaggerConfig.cs
@@ -27,7 +27,7 @@ namespace Esfa.Vacancy.Register.Api
                         // the docs is taken as the default. If your API supports multiple schemes and you want to be explicit
                         // about them, you can use the "Schemes" option as shown below.
                         //
-                        //c.Schemes(new[] { "http", "https" });
+                        c.Schemes(new[] { "https" });
 
                         // Use "SingleApiVersion" to describe a single version API. Swagger 2.0 includes an "Info" object to
                         // hold additional metadata for an API. Version and title are required but you can also provide


### PR DESCRIPTION
This si to prevent the following error:

Mixed Content: The page at 'https://sit-vacancy.apprenticeships.sfa.bis.gov.uk/api' was loaded over HTTPS, but requested an insecure image 'http://online.swagger.io/validator?url=https://sit-vacancy.apprenticeships.sfa.bis.gov.uk/swagger/docs/v1'. This content should also be served over HTTPS.