### PR TITLE
Feature/ra 1248 retry logic

### DIFF
--- a/src/Esfa.Vacancy.Register.Infrastructure/Esfa.Vacancy.Register.Infrastructure.csproj
+++ b/src/Esfa.Vacancy.Register.Infrastructure/Esfa.Vacancy.Register.Infrastructure.csproj
@@ -66,6 +66,10 @@
       <HintPath>..\packages\NLog.4.4.11\lib\net45\NLog.dll</HintPath>
       <Private>True</Private>
     </Reference>
+    <Reference Include="Polly, Version=5.3.1.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\Polly.5.3.1\lib\net45\Polly.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
     <Reference Include="SFA.DAS.Apprenticeships.Api.Client, Version=0.10.87.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\packages\SFA.DAS.Apprenticeships.Api.Client.0.10.87\lib\net45\SFA.DAS.Apprenticeships.Api.Client.dll</HintPath>
       <Private>True</Private>
@@ -115,6 +119,7 @@
     <Compile Include="Settings\ApplicationSettings.cs" />
     <Compile Include="Settings\IProvideSettings.cs" />
     <Compile Include="Settings\MachineSettings.cs" />
+    <Compile Include="VacancyRegisterRetryPolicy.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="app.config" />

--- a/src/Esfa.Vacancy.Register.Infrastructure/Repositories/VacancyRepository.cs
+++ b/src/Esfa.Vacancy.Register.Infrastructure/Repositories/VacancyRepository.cs
@@ -24,7 +24,7 @@ namespace Esfa.Vacancy.Register.Infrastructure.Repositories
 
         public async Task<DomainEntities.Vacancy> GetVacancyByReferenceNumberAsync(int referenceNumber)
         {
-            var retry = VacancyRegisterRetryPolicy.GetFixedInterval((exception, time, retryCount, context) =>
+            var retry = VacancyRegisterRetryPolicy.GetFixedIntervalPolicy((exception, time, retryCount, context) =>
             {
                 _logger.Warn($"Error retrieving vacancy from VacancyRepository: ({exception.Message}). Retrying...attempt {retryCount})");
             });

--- a/src/Esfa.Vacancy.Register.Infrastructure/Repositories/VacancyRepository.cs
+++ b/src/Esfa.Vacancy.Register.Infrastructure/Repositories/VacancyRepository.cs
@@ -26,7 +26,7 @@ namespace Esfa.Vacancy.Register.Infrastructure.Repositories
         {
             var retry = VacancyRegisterRetryPolicy.GetFixedIntervalPolicy((exception, time, retryCount, context) =>
             {
-                _logger.Warn($"Error retrieving vacancy from VacancyRepository: ({exception.Message}). Retrying...attempt {retryCount})");
+                _logger.Warn($"Error retrieving vacancy from database: ({exception.Message}). Retrying...attempt {retryCount})");
             });
             
             return await retry.ExecuteAsync(() => InternalGetVacancyByReferenceNumberAsync(referenceNumber));

--- a/src/Esfa.Vacancy.Register.Infrastructure/Services/TrainingDetailService.cs
+++ b/src/Esfa.Vacancy.Register.Infrastructure/Services/TrainingDetailService.cs
@@ -23,7 +23,7 @@ namespace Esfa.Vacancy.Register.Infrastructure.Services
 
         public async Task<Framework> GetFrameworkDetailsAsync(int code)
         {
-            var retry = VacancyRegisterRetryPolicy.GetFixedInterval((exception, time, retryCount, context) =>
+            var retry = VacancyRegisterRetryPolicy.GetFixedIntervalPolicy((exception, time, retryCount, context) =>
             {
                 _logger.Warn($"Error retrieving framework details from TrainingDetailService: ({exception.Message}). Retrying...attempt {retryCount})");
             });
@@ -50,7 +50,7 @@ namespace Esfa.Vacancy.Register.Infrastructure.Services
 
         public async Task<Standard> GetStandardDetailsAsync(int code)
         {
-            var retry = VacancyRegisterRetryPolicy.GetFixedInterval((exception, time, retryCount, context) =>
+            var retry = VacancyRegisterRetryPolicy.GetFixedIntervalPolicy((exception, time, retryCount, context) =>
             {
                 _logger.Warn($"Error retrieving standard details from TrainingDetailService: ({exception.Message}). Retrying...attempt {retryCount})");
             });

--- a/src/Esfa.Vacancy.Register.Infrastructure/Services/TrainingDetailService.cs
+++ b/src/Esfa.Vacancy.Register.Infrastructure/Services/TrainingDetailService.cs
@@ -1,4 +1,5 @@
-﻿using System.Threading.Tasks;
+﻿using System;
+using System.Threading.Tasks;
 using Esfa.Vacancy.Register.Application.Interfaces;
 using Esfa.Vacancy.Register.Domain.Entities;
 using Esfa.Vacancy.Register.Infrastructure.Settings;
@@ -22,6 +23,16 @@ namespace Esfa.Vacancy.Register.Infrastructure.Services
 
         public async Task<Framework> GetFrameworkDetailsAsync(int code)
         {
+            var retry = VacancyRegisterRetryPolicy.GetFixedInterval((exception, time, retryCount, context) =>
+            {
+                _logger.Warn($"Error retrieving framework details from TrainingDetailService: ({exception.Message}). Retrying...attempt {retryCount})");
+            });
+
+            return await retry.ExecuteAsync(() => InternalGetFrameworkDetailsAsync(code));
+        }
+
+        private async Task<Framework> InternalGetFrameworkDetailsAsync(int code)
+        {
             using (var client = new FrameworkCodeClient(_dasApiBaseUrl))
             {
                 try
@@ -38,6 +49,16 @@ namespace Esfa.Vacancy.Register.Infrastructure.Services
         }
 
         public async Task<Standard> GetStandardDetailsAsync(int code)
+        {
+            var retry = VacancyRegisterRetryPolicy.GetFixedInterval((exception, time, retryCount, context) =>
+            {
+                _logger.Warn($"Error retrieving standard details from TrainingDetailService: ({exception.Message}). Retrying...attempt {retryCount})");
+            });
+
+            return await retry.ExecuteAsync(() => InternalGetStandardDetailsAsync(code));
+        }
+
+        private async Task<Standard> InternalGetStandardDetailsAsync(int code)
         {
             using (var client = new StandardApiClient(_dasApiBaseUrl))
             {

--- a/src/Esfa.Vacancy.Register.Infrastructure/VacancyRegisterRetryPolicy.cs
+++ b/src/Esfa.Vacancy.Register.Infrastructure/VacancyRegisterRetryPolicy.cs
@@ -5,11 +5,14 @@ namespace Esfa.Vacancy.Register.Infrastructure
 {
     public static class VacancyRegisterRetryPolicy
     {
+        private const int RetryCount = 3;
+        private const int SleepDurationMilliseconds = 500;
+
         public static Policy GetFixedIntervalPolicy(Action<Exception, TimeSpan, int, Context> onRetry)
         {
             return Policy
                 .Handle<Exception>()
-                .WaitAndRetryAsync(3, (attempt) => TimeSpan.FromMilliseconds(500),
+                .WaitAndRetryAsync(RetryCount, (attempt) => TimeSpan.FromMilliseconds(SleepDurationMilliseconds),
                 onRetry);
         }
     }

--- a/src/Esfa.Vacancy.Register.Infrastructure/VacancyRegisterRetryPolicy.cs
+++ b/src/Esfa.Vacancy.Register.Infrastructure/VacancyRegisterRetryPolicy.cs
@@ -5,7 +5,7 @@ namespace Esfa.Vacancy.Register.Infrastructure
 {
     public static class VacancyRegisterRetryPolicy
     {
-        public static Policy GetFixedInterval(Action<Exception, TimeSpan, int, Context> onRetry)
+        public static Policy GetFixedIntervalPolicy(Action<Exception, TimeSpan, int, Context> onRetry)
         {
             return Policy
                 .Handle<Exception>()

--- a/src/Esfa.Vacancy.Register.Infrastructure/VacancyRegisterRetryPolicy.cs
+++ b/src/Esfa.Vacancy.Register.Infrastructure/VacancyRegisterRetryPolicy.cs
@@ -1,0 +1,16 @@
+﻿using System;
+using Polly;
+
+namespace Esfa.Vacancy.Register.Infrastructure
+{
+    public static class VacancyRegisterRetryPolicy
+    {
+        public static Policy GetFixedInterval(Action<Exception, TimeSpan, int, Context> onRetry)
+        {
+            return Policy
+                .Handle<Exception>()
+                .WaitAndRetryAsync(3, (attempt) => TimeSpan.FromMilliseconds(500),
+                onRetry);
+        }
+    }
+}

--- a/src/Esfa.Vacancy.Register.Infrastructure/packages.config
+++ b/src/Esfa.Vacancy.Register.Infrastructure/packages.config
@@ -11,6 +11,7 @@
   <package id="NEST" version="1.9.2" targetFramework="net452" />
   <package id="Newtonsoft.Json" version="9.0.1" targetFramework="net452" />
   <package id="NLog" version="4.4.11" targetFramework="net452" />
+  <package id="Polly" version="5.3.1" targetFramework="net452" />
   <package id="SFA.DAS.Apprenticeships.Api.Client" version="0.10.87" targetFramework="net452" />
   <package id="SFA.DAS.Apprenticeships.Api.Types" version="0.10.87" targetFramework="net452" />
   <package id="SFA.DAS.NLog.Logger" version="1.0.0.39208" targetFramework="net452" />

--- a/src/Esfa.Vacancy.Register.UnitTests/Esfa.Vacancy.Register.UnitTests.csproj
+++ b/src/Esfa.Vacancy.Register.UnitTests/Esfa.Vacancy.Register.UnitTests.csproj
@@ -74,6 +74,10 @@
       <HintPath>..\packages\AutoFixture.3.50.6\lib\net40\Ploeh.AutoFixture.dll</HintPath>
       <Private>True</Private>
     </Reference>
+    <Reference Include="Polly, Version=5.3.1.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\Polly.5.3.1\lib\net45\Polly.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
     <Reference Include="SFA.DAS.NLog.Logger, Version=1.0.0.39208, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\packages\SFA.DAS.NLog.Logger.1.0.0.39208\lib\net45\SFA.DAS.NLog.Logger.dll</HintPath>
       <Private>True</Private>
@@ -93,6 +97,7 @@
   <ItemGroup>
     <Compile Include="Api\App_Start\GivenAnApiFilterConfig.cs" />
     <Compile Include="Api\Mappings\IntToEnumConverterTests.cs" />
+    <Compile Include="Infrastructure\WhenVacancyRegisterRetryPolicy.cs" />
     <Compile Include="SearchApprenticeship\Api\GivenSearchApprenticeshipParameters\AndPageNumber.cs" />
     <Compile Include="SearchApprenticeship\Api\GivenSearchApprenticeshipParameters\AndPageSize.cs" />
     <Compile Include="SearchApprenticeship\Api\GivenSearchApprenticeshipParameters\AndStandardCodes.cs" />

--- a/src/Esfa.Vacancy.Register.UnitTests/Infrastructure/WhenVacancyRegisterRetryPolicy.cs
+++ b/src/Esfa.Vacancy.Register.UnitTests/Infrastructure/WhenVacancyRegisterRetryPolicy.cs
@@ -20,7 +20,7 @@ namespace Esfa.Vacancy.Register.UnitTests.Infrastructure
             var message = "error";
             var retries = new List<Tuple<string, TimeSpan, int>>();
 
-            var policy = VacancyRegisterRetryPolicy.GetFixedInterval((exception, timeSpan, retryCount, context) =>
+            var policy = VacancyRegisterRetryPolicy.GetFixedIntervalPolicy((exception, timeSpan, retryCount, context) =>
             {
                 retries.Add(new Tuple<string, TimeSpan, int>(exception.Message, timeSpan, retryCount));
             });

--- a/src/Esfa.Vacancy.Register.UnitTests/Infrastructure/WhenVacancyRegisterRetryPolicy.cs
+++ b/src/Esfa.Vacancy.Register.UnitTests/Infrastructure/WhenVacancyRegisterRetryPolicy.cs
@@ -1,0 +1,55 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Esfa.Vacancy.Register.Infrastructure;
+using FluentAssertions;
+using NUnit.Framework;
+using FluentAssertions.Specialized;
+
+namespace Esfa.Vacancy.Register.UnitTests.Infrastructure
+{
+    [TestFixture]
+    [Parallelizable]
+    public class WhenVacancyRegisterRetryPolicy
+    {
+        [Test]
+        public void ThenShouldReturnGetFixedInterval()
+        {
+            var message = "error";
+            var retries = new List<Tuple<string, TimeSpan, int>>();
+
+            var policy = VacancyRegisterRetryPolicy.GetFixedInterval((exception, timeSpan, retryCount, context) =>
+            {
+                retries.Add(new Tuple<string, TimeSpan, int>(exception.Message, timeSpan, retryCount));
+            });
+
+            Func<Task> act = async () =>
+            {
+                await policy.ExecuteAsync(() =>
+                {
+                    message += "x";
+                    throw new Exception(message);
+                });
+            };
+
+            //Should throw the 4th exception
+            act.ShouldThrow<Exception>().WithMessage("errorxxxx");
+
+            //Should retry 3 times with a 500ms pause between retries.
+            //see https://docs.microsoft.com/en-us/azure/architecture/best-practices/retry-service-specific#sql-database-using-adonet-retry-guidelines
+            retries[0].Item1.Should().Be("errorx");
+            retries[0].Item2.Should().Be(TimeSpan.FromMilliseconds(500));
+            retries[0].Item3.Should().Be(1);
+
+            retries[1].Item1.Should().Be("errorxx");
+            retries[1].Item2.Should().Be(TimeSpan.FromMilliseconds(500));
+            retries[1].Item3.Should().Be(2);
+
+            retries[2].Item1.Should().Be("errorxxx");
+            retries[2].Item2.Should().Be(TimeSpan.FromMilliseconds(500));
+            retries[2].Item3.Should().Be(3);
+        }
+    }
+}

--- a/src/Esfa.Vacancy.Register.UnitTests/packages.config
+++ b/src/Esfa.Vacancy.Register.UnitTests/packages.config
@@ -12,5 +12,6 @@
   <package id="Newtonsoft.Json" version="9.0.1" targetFramework="net452" />
   <package id="NLog" version="4.4.11" targetFramework="net452" />
   <package id="NUnit" version="3.7.1" targetFramework="net452" />
+  <package id="Polly" version="5.3.1" targetFramework="net452" />
   <package id="SFA.DAS.NLog.Logger" version="1.0.0.39208" targetFramework="net452" />
 </packages>


### PR DESCRIPTION
I've added Polly to handle retries around resource requests.

For the time being the retry will fire 3 times with a wait of 500ms for all unhandled exceptions.  This retry period/wait is an Azure recommendation from here. https://docs.microsoft.com/en-us/azure/architecture/best-practices/retry-service-specific.

There may be only a subset of exceptions we want to retry on rather than all unhandled. However my current thinking is to observe the logs first to understand the types of exceptions we are seeing before we look to optimise.