### PR TITLE
Enum values should be displayed as strings in swagger ui

### DIFF
--- a/src/Esfa.Vacancy.Register.Api/App_Start/SwaggerConfig.cs
+++ b/src/Esfa.Vacancy.Register.Api/App_Start/SwaggerConfig.cs
@@ -140,7 +140,7 @@ namespace Esfa.Vacancy.Register.Api
                         // enum type. Swashbuckle will honor this change out-of-the-box. However, if you use a different
                         // approach to serialize enums as strings, you can also force Swashbuckle to describe them as strings.
                         // 
-                        //c.DescribeAllEnumsAsStrings();
+                        c.DescribeAllEnumsAsStrings();
 
                         // Similar to Schema filters, Swashbuckle also supports Operation and Document filters:
                         //


### PR DESCRIPTION
This does not disrupt or override the StrictEnumConverter @mgwilliam added. This is more for the default value shown in the below section.

![image](https://user-images.githubusercontent.com/10399742/32104876-38fed332-bb1e-11e7-9e3c-8b13e62cd9ef.png)

As you can see WageUnit default value is 'Unspecified' instead of showing as 0.