### PR TITLE
RA-1286 match search and detail response object

### DIFF
--- a/src/Esfa.Vacancy.Api.Types/ApprenticeshipSummary.cs
+++ b/src/Esfa.Vacancy.Api.Types/ApprenticeshipSummary.cs
@@ -40,16 +40,6 @@ namespace Esfa.Vacancy.Api.Types
         public decimal? HoursPerWeek { get; set; }
 
         /// <summary>
-        /// The type of the wage.
-        /// </summary>
-        public int WageType { get; set; }
-
-        /// <summary>
-        /// The wage amount.
-        /// </summary>
-        public decimal? WageAmount { get; set; }
-
-        /// <summary>
         /// Expected start date.
         /// </summary>
         public DateTime ExpectedStartDate { get; set; }

--- a/src/Esfa.Vacancy.Api.Types/ApprenticeshipSummary.cs
+++ b/src/Esfa.Vacancy.Api.Types/ApprenticeshipSummary.cs
@@ -88,9 +88,9 @@ namespace Esfa.Vacancy.Api.Types
         public string TrainingProviderName { get; set; }
 
         /// <summary>
-        /// The type of the vacancy location.
+        /// Is this vacancy available nationwide.
         /// </summary>
-        public string VacancyLocationType { get; set; }
+        public bool IsNationwide { get; set; }
 
         /// <summary>
         /// The location.

--- a/src/Esfa.Vacancy.Api.Types/ApprenticeshipSummary.cs
+++ b/src/Esfa.Vacancy.Api.Types/ApprenticeshipSummary.cs
@@ -15,9 +15,9 @@ namespace Esfa.Vacancy.Api.Types
         public string Title { get; set; }
 
         /// <summary>
-        /// The description.
+        /// The short description of the vacancy.
         /// </summary>
-        public string Description { get; set; }
+        public string ShortDescription { get; set; }
 
         /// <summary>
         /// Wage unit.

--- a/src/Esfa.Vacancy.Api.Types/ApprenticeshipSummary.cs
+++ b/src/Esfa.Vacancy.Api.Types/ApprenticeshipSummary.cs
@@ -95,7 +95,7 @@ namespace Esfa.Vacancy.Api.Types
         /// <value>
         /// The name of the provider.
         /// </value>
-        public string ProviderName { get; set; }
+        public string TrainingProviderName { get; set; }
 
         /// <summary>
         /// The type of the vacancy location.

--- a/src/Esfa.Vacancy.Api.Types/ApprenticeshipSummary.cs
+++ b/src/Esfa.Vacancy.Api.Types/ApprenticeshipSummary.cs
@@ -22,7 +22,7 @@ namespace Esfa.Vacancy.Api.Types
         /// <summary>
         /// Wage unit.
         /// </summary>
-        public WageUnit? WageUnit { get; set; }
+        public WageUnit WageUnit { get; set; }
 
         /// <summary>
         /// Working week.

--- a/src/Esfa.Vacancy.Api.Types/ApprenticeshipVacancy.cs
+++ b/src/Esfa.Vacancy.Api.Types/ApprenticeshipVacancy.cs
@@ -190,7 +190,7 @@ namespace Esfa.Vacancy.Api.Types
         /// <summary>
         /// The training provider's trading name
         /// </summary>
-        public string TrainingProvider { get; set; }
+        public string TrainingProviderName { get; set; }
 
         /// <summary>
         /// The training provider's UKPRN

--- a/src/Esfa.Vacancy.Api.Types/ApprenticeshipVacancy.cs
+++ b/src/Esfa.Vacancy.Api.Types/ApprenticeshipVacancy.cs
@@ -148,9 +148,9 @@ namespace Esfa.Vacancy.Api.Types
         public string ThingsToConsider { get; set; }
 
         /// <summary>
-        /// Is this vacancy available nation wide.
+        /// Is this vacancy available nationwide.
         /// </summary>
-        public bool IsNationWide { get; set; }
+        public bool IsNationwide { get; set; }
 
         /// <summary>
         /// Supplementary question1.

--- a/src/Esfa.Vacancy.Api.Types/ApprenticeshipVacancy.cs
+++ b/src/Esfa.Vacancy.Api.Types/ApprenticeshipVacancy.cs
@@ -148,9 +148,9 @@ namespace Esfa.Vacancy.Api.Types
         public string ThingsToConsider { get; set; }
 
         /// <summary>
-        /// Type of the vacancy location.
+        /// Is this vacancy available nation wide.
         /// </summary>
-        public VacancyLocationType LocationType { get; set; }
+        public bool IsNationWide { get; set; }
 
         /// <summary>
         /// Supplementary question1.

--- a/src/Esfa.Vacancy.Api.Types/ApprenticeshipVacancy.cs
+++ b/src/Esfa.Vacancy.Api.Types/ApprenticeshipVacancy.cs
@@ -18,20 +18,20 @@ namespace Esfa.Vacancy.Api.Types
         public string Title { get; set; }
 
         /// <summary>
-        /// Short description.
+        /// The short description of the vacancy.
         /// </summary>
         public string ShortDescription { get; set; }
 
         /// <summary>
-        /// Description.
+        /// The long description of the vacancy.
         /// </summary>
         public string Description { get; set; }
-        
+
         /// <summary>
         /// Wage unit.
         /// </summary>
         public WageUnit WageUnit { get; set; }
-        
+
         /// <summary>
         /// Working week.
         /// </summary>

--- a/src/Esfa.Vacancy.Api.Types/TraineeshipVacancy.cs
+++ b/src/Esfa.Vacancy.Api.Types/TraineeshipVacancy.cs
@@ -118,9 +118,9 @@ namespace Esfa.Vacancy.Api.Types
         public string ThingsToConsider { get; set; }
 
         /// <summary>
-        /// Is this vacancy available nation wide.
+        /// Is this vacancy available nationwide.
         /// </summary>
-        public bool IsNationWide { get; set; }
+        public bool IsNationwide { get; set; }
 
         /// <summary>
         /// Supplementary question1.

--- a/src/Esfa.Vacancy.Api.Types/TraineeshipVacancy.cs
+++ b/src/Esfa.Vacancy.Api.Types/TraineeshipVacancy.cs
@@ -26,12 +26,12 @@ namespace Esfa.Vacancy.Api.Types
         /// Description.
         /// </summary>
         public string Description { get; set; }
-        
+
         /// <summary>
         /// Working week.
         /// </summary>
         public string WorkingWeek { get; set; }
-        
+
         /// <summary>
         /// Expected duration.
         /// </summary>
@@ -118,9 +118,9 @@ namespace Esfa.Vacancy.Api.Types
         public string ThingsToConsider { get; set; }
 
         /// <summary>
-        /// Type of the vacancy location.
+        /// Is this vacancy available nation wide.
         /// </summary>
-        public VacancyLocationType LocationType { get; set; }
+        public bool IsNationWide { get; set; }
 
         /// <summary>
         /// Supplementary question1.

--- a/src/Esfa.Vacancy.Register.Api/Mappings/ApprenticeshipMapper.cs
+++ b/src/Esfa.Vacancy.Register.Api/Mappings/ApprenticeshipMapper.cs
@@ -56,7 +56,7 @@ namespace Esfa.Vacancy.Register.Api.Mappings
                 ContactName = apprenticeshipVacancy.ContactName,
                 ContactEmail = apprenticeshipVacancy.ContactEmail,
                 ContactNumber = apprenticeshipVacancy.ContactNumber,
-                TrainingProvider = apprenticeshipVacancy.TrainingProvider,
+                TrainingProviderName = apprenticeshipVacancy.TrainingProvider,
                 TrainingProviderUkprn = apprenticeshipVacancy.TrainingProviderUkprn,
                 TrainingProviderSite = apprenticeshipVacancy.TrainingProviderSite
             };

--- a/src/Esfa.Vacancy.Register.Api/Mappings/ApprenticeshipMapper.cs
+++ b/src/Esfa.Vacancy.Register.Api/Mappings/ApprenticeshipMapper.cs
@@ -12,7 +12,7 @@ namespace Esfa.Vacancy.Register.Api.Mappings
         private readonly IProvideSettings _provideSettings;
         private readonly AddressMapper _addressMapper = new AddressMapper();
         private const string UnknownText = "Unknown";
-        private const int NationWide = 3;
+        private const int Nationwide = 3;
 
         public ApprenticeshipMapper(IProvideSettings provideSettings)
         {
@@ -49,7 +49,7 @@ namespace Esfa.Vacancy.Register.Api.Mappings
                 ImportantInformation = apprenticeshipVacancy.ImportantInformation,
                 FutureProspects = apprenticeshipVacancy.FutureProspects,
                 ThingsToConsider = apprenticeshipVacancy.ThingsToConsider,
-                IsNationWide = apprenticeshipVacancy.VacancyLocationTypeId == NationWide,
+                IsNationwide = apprenticeshipVacancy.VacancyLocationTypeId == Nationwide,
                 SupplementaryQuestion1 = apprenticeshipVacancy.SupplementaryQuestion1,
                 SupplementaryQuestion2 = apprenticeshipVacancy.SupplementaryQuestion2,
                 VacancyUrl = $"{liveVacancyBaseUrl}/{apprenticeshipVacancy.VacancyReferenceNumber}",

--- a/src/Esfa.Vacancy.Register.Api/Mappings/ApprenticeshipMapper.cs
+++ b/src/Esfa.Vacancy.Register.Api/Mappings/ApprenticeshipMapper.cs
@@ -12,6 +12,7 @@ namespace Esfa.Vacancy.Register.Api.Mappings
         private readonly IProvideSettings _provideSettings;
         private readonly AddressMapper _addressMapper = new AddressMapper();
         private const string UnknownText = "Unknown";
+        private const int NationWide = 3;
 
         public ApprenticeshipMapper(IProvideSettings provideSettings)
         {
@@ -48,7 +49,7 @@ namespace Esfa.Vacancy.Register.Api.Mappings
                 ImportantInformation = apprenticeshipVacancy.ImportantInformation,
                 FutureProspects = apprenticeshipVacancy.FutureProspects,
                 ThingsToConsider = apprenticeshipVacancy.ThingsToConsider,
-                LocationType = (VacancyLocationType)apprenticeshipVacancy.VacancyLocationTypeId,
+                IsNationWide = apprenticeshipVacancy.VacancyLocationTypeId == NationWide,
                 SupplementaryQuestion1 = apprenticeshipVacancy.SupplementaryQuestion1,
                 SupplementaryQuestion2 = apprenticeshipVacancy.SupplementaryQuestion2,
                 VacancyUrl = $"{liveVacancyBaseUrl}/{apprenticeshipVacancy.VacancyReferenceNumber}",

--- a/src/Esfa.Vacancy.Register.Api/Mappings/ApprenticeshipSummaryMapper.cs
+++ b/src/Esfa.Vacancy.Register.Api/Mappings/ApprenticeshipSummaryMapper.cs
@@ -17,7 +17,8 @@ namespace Esfa.Vacancy.Register.Api.Mappings
                     source.StandardLarsCode.HasValue ? ApiTypes.TrainingType.Standard : ApiTypes.TrainingType.Framework))
                 .ForMember(target => target.TrainingTitle, c => c.MapFrom(source => source.SubCategory))
                 .ForMember(target => target.TrainingCode, c => c.MapFrom(source =>
-                    source.StandardLarsCode.HasValue ? source.StandardLarsCode.ToString() : source.FrameworkLarsCode));
+                    source.StandardLarsCode.HasValue ? source.StandardLarsCode.ToString() : source.FrameworkLarsCode))
+                .ForMember(target => target.ShortDescription, c => c.MapFrom(source => source.Description));
         }
     }
 }

--- a/src/Esfa.Vacancy.Register.Api/Mappings/ApprenticeshipSummaryMapper.cs
+++ b/src/Esfa.Vacancy.Register.Api/Mappings/ApprenticeshipSummaryMapper.cs
@@ -18,7 +18,8 @@ namespace Esfa.Vacancy.Register.Api.Mappings
                 .ForMember(target => target.TrainingTitle, c => c.MapFrom(source => source.SubCategory))
                 .ForMember(target => target.TrainingCode, c => c.MapFrom(source =>
                     source.StandardLarsCode.HasValue ? source.StandardLarsCode.ToString() : source.FrameworkLarsCode))
-                .ForMember(target => target.ShortDescription, c => c.MapFrom(source => source.Description));
+                .ForMember(target => target.ShortDescription, c => c.MapFrom(source => source.Description))
+                .ForMember(target => target.TrainingProviderName, c => c.MapFrom(source => source.ProviderName));
         }
     }
 }

--- a/src/Esfa.Vacancy.Register.Api/Mappings/ApprenticeshipSummaryMapper.cs
+++ b/src/Esfa.Vacancy.Register.Api/Mappings/ApprenticeshipSummaryMapper.cs
@@ -7,6 +7,7 @@ namespace Esfa.Vacancy.Register.Api.Mappings
 {
     public class ApprenticeshipSummaryMapper : Profile
     {
+        private const string National = "National";
         public ApprenticeshipSummaryMapper()
         {
             CreateMap<DomainTypes.ApprenticeshipSummary, ApiTypes.ApprenticeshipSummary>()
@@ -19,7 +20,8 @@ namespace Esfa.Vacancy.Register.Api.Mappings
                 .ForMember(target => target.TrainingCode, c => c.MapFrom(source =>
                     source.StandardLarsCode.HasValue ? source.StandardLarsCode.ToString() : source.FrameworkLarsCode))
                 .ForMember(target => target.ShortDescription, c => c.MapFrom(source => source.Description))
-                .ForMember(target => target.TrainingProviderName, c => c.MapFrom(source => source.ProviderName));
+                .ForMember(target => target.TrainingProviderName, c => c.MapFrom(source => source.ProviderName))
+                .ForMember(target => target.IsNationwide, c => c.MapFrom(source => source.VacancyLocationType.Equals(National)));
         }
     }
 }

--- a/src/Esfa.Vacancy.Register.Api/Mappings/TraineeshipMapper.cs
+++ b/src/Esfa.Vacancy.Register.Api/Mappings/TraineeshipMapper.cs
@@ -8,6 +8,7 @@ namespace Esfa.Vacancy.Register.Api.Mappings
     {
         private readonly IProvideSettings _provideSettings;
         private readonly AddressMapper _addressMapper = new AddressMapper();
+        private const int NationWide = 3;
 
         public TraineeshipMapper(IProvideSettings provideSettings)
         {
@@ -42,7 +43,7 @@ namespace Esfa.Vacancy.Register.Api.Mappings
                 ImportantInformation = traineeshipVacancy.ImportantInformation,
                 FutureProspects = traineeshipVacancy.FutureProspects,
                 ThingsToConsider = traineeshipVacancy.ThingsToConsider,
-                LocationType = (VacancyLocationType)traineeshipVacancy.VacancyLocationTypeId,
+                IsNationWide = traineeshipVacancy.VacancyLocationTypeId == NationWide,
                 SupplementaryQuestion1 = traineeshipVacancy.SupplementaryQuestion1,
                 SupplementaryQuestion2 = traineeshipVacancy.SupplementaryQuestion2,
                 VacancyUrl = $"{liveVacancyBaseUrl}/{traineeshipVacancy.VacancyReferenceNumber}",

--- a/src/Esfa.Vacancy.Register.Api/Mappings/TraineeshipMapper.cs
+++ b/src/Esfa.Vacancy.Register.Api/Mappings/TraineeshipMapper.cs
@@ -1,5 +1,4 @@
-﻿using Esfa.Vacancy.Api.Types;
-using Esfa.Vacancy.Register.Infrastructure.Settings;
+﻿using Esfa.Vacancy.Register.Infrastructure.Settings;
 using TraineeshipVacancy = Esfa.Vacancy.Api.Types.TraineeshipVacancy;
 
 namespace Esfa.Vacancy.Register.Api.Mappings
@@ -8,13 +7,13 @@ namespace Esfa.Vacancy.Register.Api.Mappings
     {
         private readonly IProvideSettings _provideSettings;
         private readonly AddressMapper _addressMapper = new AddressMapper();
-        private const int NationWide = 3;
+        private const int Nationwide = 3;
 
         public TraineeshipMapper(IProvideSettings provideSettings)
         {
             _provideSettings = provideSettings;
         }
-        
+
         public TraineeshipVacancy MapToTraineeshipVacancy(Domain.Entities.TraineeshipVacancy traineeshipVacancy)
         {
             var liveVacancyBaseUrl = _provideSettings.GetSetting(ApplicationSettingKeyConstants.LiveTraineeshipVacancyBaseUrlKey);
@@ -43,7 +42,7 @@ namespace Esfa.Vacancy.Register.Api.Mappings
                 ImportantInformation = traineeshipVacancy.ImportantInformation,
                 FutureProspects = traineeshipVacancy.FutureProspects,
                 ThingsToConsider = traineeshipVacancy.ThingsToConsider,
-                IsNationWide = traineeshipVacancy.VacancyLocationTypeId == NationWide,
+                IsNationwide = traineeshipVacancy.VacancyLocationTypeId == Nationwide,
                 SupplementaryQuestion1 = traineeshipVacancy.SupplementaryQuestion1,
                 SupplementaryQuestion2 = traineeshipVacancy.SupplementaryQuestion2,
                 VacancyUrl = $"{liveVacancyBaseUrl}/{traineeshipVacancy.VacancyReferenceNumber}",

--- a/src/Esfa.Vacancy.Register.UnitTests/Esfa.Vacancy.Register.UnitTests.csproj
+++ b/src/Esfa.Vacancy.Register.UnitTests/Esfa.Vacancy.Register.UnitTests.csproj
@@ -105,6 +105,7 @@
     <Reference Include="System.Xml.Linq" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="GetApprenticeshipVacancy\Api\Mappings\GivenAnApprenticeshipMapper\WhenMappingIsNationWide.cs" />
     <Compile Include="GetTraineeshipVacancy\Api\Mappings\GivenTraineeshipMapper.cs" />
     <Compile Include="Shared\Infrastructure\GivenACachedFrameworkCodeRepository\WhenCallingGetAsync.cs" />
     <Compile Include="Shared\Infrastructure\GivenACachedStandardRepository\WhenCallingGetStandardIdsAsync.cs" />

--- a/src/Esfa.Vacancy.Register.UnitTests/Esfa.Vacancy.Register.UnitTests.csproj
+++ b/src/Esfa.Vacancy.Register.UnitTests/Esfa.Vacancy.Register.UnitTests.csproj
@@ -105,7 +105,7 @@
     <Reference Include="System.Xml.Linq" />
   </ItemGroup>
   <ItemGroup>
-    <Compile Include="GetApprenticeshipVacancy\Api\Mappings\GivenAnApprenticeshipMapper\WhenMappingIsNationWide.cs" />
+    <Compile Include="GetApprenticeshipVacancy\Api\Mappings\GivenAnApprenticeshipMapper\WhenMappingIsNationwide.cs" />
     <Compile Include="GetTraineeshipVacancy\Api\Mappings\GivenTraineeshipMapper.cs" />
     <Compile Include="Shared\Infrastructure\GivenACachedFrameworkCodeRepository\WhenCallingGetAsync.cs" />
     <Compile Include="Shared\Infrastructure\GivenACachedStandardRepository\WhenCallingGetStandardIdsAsync.cs" />

--- a/src/Esfa.Vacancy.Register.UnitTests/Esfa.Vacancy.Register.UnitTests.csproj
+++ b/src/Esfa.Vacancy.Register.UnitTests/Esfa.Vacancy.Register.UnitTests.csproj
@@ -105,6 +105,7 @@
     <Reference Include="System.Xml.Linq" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="GetTraineeshipVacancy\Api\Mappings\GivenTraineeshipMapper.cs" />
     <Compile Include="Shared\Infrastructure\GivenACachedFrameworkCodeRepository\WhenCallingGetAsync.cs" />
     <Compile Include="Shared\Infrastructure\GivenACachedStandardRepository\WhenCallingGetStandardIdsAsync.cs" />
     <Compile Include="SearchApprenticeship\Application\GivenAVacancySearchParametersMapper\AndFrameworkLarsCodes.cs" />

--- a/src/Esfa.Vacancy.Register.UnitTests/GetApprenticeshipVacancy/Api/Mappings/GivenAnApprenticeshipMapper/WhenMappingIsNationWide.cs
+++ b/src/Esfa.Vacancy.Register.UnitTests/GetApprenticeshipVacancy/Api/Mappings/GivenAnApprenticeshipMapper/WhenMappingIsNationWide.cs
@@ -7,6 +7,7 @@ using DomainTypes = Esfa.Vacancy.Register.Domain.Entities;
 
 namespace Esfa.Vacancy.Register.UnitTests.GetApprenticeshipVacancy.Api.Mappings.GivenAnApprenticeshipMapper
 {
+    [TestFixture]
     public class WhenMappingIsNationwide
     {
         private ApprenticeshipMapper _sut;

--- a/src/Esfa.Vacancy.Register.UnitTests/GetApprenticeshipVacancy/Api/Mappings/GivenAnApprenticeshipMapper/WhenMappingIsNationWide.cs
+++ b/src/Esfa.Vacancy.Register.UnitTests/GetApprenticeshipVacancy/Api/Mappings/GivenAnApprenticeshipMapper/WhenMappingIsNationWide.cs
@@ -1,0 +1,37 @@
+﻿using Esfa.Vacancy.Register.Api.Mappings;
+using Esfa.Vacancy.Register.Infrastructure.Settings;
+using FluentAssertions;
+using Moq;
+using NUnit.Framework;
+using DomainTypes = Esfa.Vacancy.Register.Domain.Entities;
+
+namespace Esfa.Vacancy.Register.UnitTests.GetApprenticeshipVacancy.Api.Mappings.GivenAnApprenticeshipMapper
+{
+    public class WhenMappingIsNationWide
+    {
+        private ApprenticeshipMapper _sut;
+
+        [OneTimeSetUp]
+        public void FixtureSetup()
+        {
+            var provideSettings = new Mock<IProvideSettings>();
+            _sut = new ApprenticeshipMapper(provideSettings.Object);
+        }
+
+        [TestCase(1, false, TestName = "And LocationTypeId is 1 Then set IsNationWide to false")]
+        [TestCase(2, false, TestName = "And LocationTypeId is 2 Then set IsNationWide to false")]
+        [TestCase(3, true, TestName = "And LocationTypeId is 3 Then set IsNationWide to true")]
+        public void ShouldMapUsingLocationTypeId(int vacancyLocationTypeid, bool expectedResult)
+        {
+            var vacancy = new DomainTypes.ApprenticeshipVacancy()
+            {
+                VacancyLocationTypeId = vacancyLocationTypeid,
+                Location = new DomainTypes.Address()
+            };
+
+            var result = _sut.MapToApprenticeshipVacancy(vacancy);
+
+            result.IsNationWide.Should().Be(expectedResult);
+        }
+    }
+}

--- a/src/Esfa.Vacancy.Register.UnitTests/GetApprenticeshipVacancy/Api/Mappings/GivenAnApprenticeshipMapper/WhenMappingIsNationWide.cs
+++ b/src/Esfa.Vacancy.Register.UnitTests/GetApprenticeshipVacancy/Api/Mappings/GivenAnApprenticeshipMapper/WhenMappingIsNationWide.cs
@@ -7,7 +7,7 @@ using DomainTypes = Esfa.Vacancy.Register.Domain.Entities;
 
 namespace Esfa.Vacancy.Register.UnitTests.GetApprenticeshipVacancy.Api.Mappings.GivenAnApprenticeshipMapper
 {
-    public class WhenMappingIsNationWide
+    public class WhenMappingIsNationwide
     {
         private ApprenticeshipMapper _sut;
 
@@ -18,9 +18,9 @@ namespace Esfa.Vacancy.Register.UnitTests.GetApprenticeshipVacancy.Api.Mappings.
             _sut = new ApprenticeshipMapper(provideSettings.Object);
         }
 
-        [TestCase(1, false, TestName = "And LocationTypeId is 1 Then set IsNationWide to false")]
-        [TestCase(2, false, TestName = "And LocationTypeId is 2 Then set IsNationWide to false")]
-        [TestCase(3, true, TestName = "And LocationTypeId is 3 Then set IsNationWide to true")]
+        [TestCase(1, false, TestName = "And LocationTypeId is 1 Then set IsNationwide to false")]
+        [TestCase(2, false, TestName = "And LocationTypeId is 2 Then set IsNationwide to false")]
+        [TestCase(3, true, TestName = "And LocationTypeId is 3 Then set IsNationwide to true")]
         public void ShouldMapUsingLocationTypeId(int vacancyLocationTypeid, bool expectedResult)
         {
             var vacancy = new DomainTypes.ApprenticeshipVacancy()
@@ -31,7 +31,7 @@ namespace Esfa.Vacancy.Register.UnitTests.GetApprenticeshipVacancy.Api.Mappings.
 
             var result = _sut.MapToApprenticeshipVacancy(vacancy);
 
-            result.IsNationWide.Should().Be(expectedResult);
+            result.IsNationwide.Should().Be(expectedResult);
         }
     }
 }

--- a/src/Esfa.Vacancy.Register.UnitTests/GetTraineeshipVacancy/Api/Mappings/GivenTraineeshipMapper.cs
+++ b/src/Esfa.Vacancy.Register.UnitTests/GetTraineeshipVacancy/Api/Mappings/GivenTraineeshipMapper.cs
@@ -20,10 +20,10 @@ namespace Esfa.Vacancy.Register.UnitTests.GetTraineeshipVacancy.Api.Mappings
             _sut = new TraineeshipMapper(_provideSettingsMock.Object);
         }
 
-        [TestCase(1, false, TestName = "And LocationType is 1 Then set IsNationWide to false")]
-        [TestCase(2, false, TestName = "And LocationType is 2 Then set IsNationWide to false")]
-        [TestCase(3, true, TestName = "And LocationType is 3 Then set IsNationWide to true")]
-        public void WhenMappingIsNationWide(int vacancyLocationTypeid, bool expectedResult)
+        [TestCase(1, false, TestName = "And LocationType is 1 Then set IsNationwide to false")]
+        [TestCase(2, false, TestName = "And LocationType is 2 Then set IsNationwide to false")]
+        [TestCase(3, true, TestName = "And LocationType is 3 Then set IsNationwide to true")]
+        public void WhenMappingIsNationwide(int vacancyLocationTypeid, bool expectedResult)
         {
             var vacancy = new DomainTypes.TraineeshipVacancy()
             {
@@ -33,7 +33,7 @@ namespace Esfa.Vacancy.Register.UnitTests.GetTraineeshipVacancy.Api.Mappings
 
             var result = _sut.MapToTraineeshipVacancy(vacancy);
 
-            result.IsNationWide.Should().Be(expectedResult);
+            result.IsNationwide.Should().Be(expectedResult);
         }
 
         [TestCase("", TestName = "And Anonymous Employer Name is empty Then populate using EmployerName")]

--- a/src/Esfa.Vacancy.Register.UnitTests/GetTraineeshipVacancy/Api/Mappings/GivenTraineeshipMapper.cs
+++ b/src/Esfa.Vacancy.Register.UnitTests/GetTraineeshipVacancy/Api/Mappings/GivenTraineeshipMapper.cs
@@ -1,0 +1,97 @@
+﻿using Esfa.Vacancy.Register.Api.Mappings;
+using Esfa.Vacancy.Register.Infrastructure.Settings;
+using FluentAssertions;
+using Moq;
+using NUnit.Framework;
+using DomainTypes = Esfa.Vacancy.Register.Domain.Entities;
+
+
+namespace Esfa.Vacancy.Register.UnitTests.GetTraineeshipVacancy.Api.Mappings
+{
+    [TestFixture]
+    public class GivenTraineeshipMapper
+    {
+        private TraineeshipMapper _sut;
+        private readonly Mock<IProvideSettings> _provideSettingsMock = new Mock<IProvideSettings>();
+
+        [OneTimeSetUp]
+        public void Setup()
+        {
+            _sut = new TraineeshipMapper(_provideSettingsMock.Object);
+        }
+
+        [TestCase(1, false, TestName = "And LocationType is 1 Then set IsNationWide to false")]
+        [TestCase(2, false, TestName = "And LocationType is 2 Then set IsNationWide to false")]
+        [TestCase(3, true, TestName = "And LocationType is 3 Then set IsNationWide to true")]
+        public void WhenMappingIsNationWide(int vacancyLocationTypeid, bool expectedResult)
+        {
+            var vacancy = new DomainTypes.TraineeshipVacancy()
+            {
+                VacancyLocationTypeId = vacancyLocationTypeid,
+                Location = new DomainTypes.Address()
+            };
+
+            var result = _sut.MapToTraineeshipVacancy(vacancy);
+
+            result.IsNationWide.Should().Be(expectedResult);
+        }
+
+        [TestCase("", TestName = "And Anonymous Employer Name is empty Then populate using EmployerName")]
+        [TestCase("Anonymous name", TestName = "And Anonymous Employer Name is given Then populate using AnonymousEmployerName")]
+        public void WhenMappingEmployerName(string anonymousEmployerName)
+        {
+            var vacancy = new DomainTypes.TraineeshipVacancy()
+            {
+                EmployerName = "Employer Name",
+                AnonymousEmployerName = anonymousEmployerName,
+                Location = new DomainTypes.Address()
+            };
+
+            var expectedEmployerName =
+                string.IsNullOrWhiteSpace(vacancy.AnonymousEmployerName) ? vacancy.EmployerName : vacancy.AnonymousEmployerName;
+
+            var result = _sut.MapToTraineeshipVacancy(vacancy);
+
+            result.EmployerName.Should().Be(expectedEmployerName);
+        }
+
+        [TestCase("", TestName = "And Anonymous Employer Name is empty Then populate using EmployerDescription")]
+        [TestCase("Anonymous desc", TestName = "And Anonymous Employer Name is given Then populate using AnonymousEmployerDescription")]
+        public void WhenMappingEmployerDescription(string anonymousEmployerName)
+        {
+            var vacancy = new DomainTypes.TraineeshipVacancy()
+            {
+                AnonymousEmployerDescription = "Anonymous Employer Desc",
+                EmployerDescription = "Employer Desc",
+                AnonymousEmployerName = anonymousEmployerName,
+                Location = new DomainTypes.Address()
+            };
+
+            var expectedEmployerDescription =
+                string.IsNullOrWhiteSpace(vacancy.AnonymousEmployerName) ? vacancy.EmployerDescription : vacancy.AnonymousEmployerDescription;
+
+            var result = _sut.MapToTraineeshipVacancy(vacancy);
+
+            result.EmployerDescription.Should().Be(expectedEmployerDescription);
+        }
+
+        [TestCase("", TestName = "And Anonymous Employer Name is empty Then populate using EmployerDescription")]
+        [TestCase("Anonymous desc", TestName = "And Anonymous Employer Name is given Then populate using AnonymousEmployerDescription")]
+        public void WhenMappingEmployerWebsite(string anonymousEmployerName)
+        {
+            var vacancy = new DomainTypes.TraineeshipVacancy()
+            {
+                EmployerWebsite = "www.google.com",
+                AnonymousEmployerName = anonymousEmployerName,
+                Location = new DomainTypes.Address()
+            };
+
+            var expectedEmployerWebsite =
+                string.IsNullOrWhiteSpace(vacancy.AnonymousEmployerName) ? vacancy.EmployerWebsite : null;
+
+            var result = _sut.MapToTraineeshipVacancy(vacancy);
+
+            result.EmployerWebsite.Should().Be(expectedEmployerWebsite);
+        }
+    }
+}

--- a/src/Esfa.Vacancy.Register.UnitTests/SearchApprenticeship/Api/Mappings/GivenApprenticeshipSummaryMapper.cs
+++ b/src/Esfa.Vacancy.Register.UnitTests/SearchApprenticeship/Api/Mappings/GivenApprenticeshipSummaryMapper.cs
@@ -8,6 +8,7 @@ using DomainTypes = Esfa.Vacancy.Register.Domain.Entities;
 
 namespace Esfa.Vacancy.Register.UnitTests.SearchApprenticeship.Api.Mappings
 {
+    [TestFixture]
     public class GivenApprenticeshipSummaryMapper
     {
         private IMapper _mapper;
@@ -78,5 +79,20 @@ namespace Esfa.Vacancy.Register.UnitTests.SearchApprenticeship.Api.Mappings
 
             result.TrainingProviderName.Should().Be(providerName, "Then map ProviderName to TrainingProviderName");
         }
+
+        [TestCase("National", true, TestName = "And Location Type is National Then map set IsNationWide to true")]
+        [TestCase("NonNational", false, TestName = "And Location Type is NonNational Then map set IsNationWide to false")]
+        public void WhenMappingIsNationWide(string value, bool expectedResult)
+        {
+            var domainType = new DomainTypes.ApprenticeshipSummary
+            {
+                VacancyLocationType = value
+            };
+
+            var result = _mapper.Map<ApiTypes.ApprenticeshipSummary>(domainType);
+
+            result.IsNationwide.Should().Be(expectedResult);
+        }
+
     }
 }

--- a/src/Esfa.Vacancy.Register.UnitTests/SearchApprenticeship/Api/Mappings/GivenApprenticeshipSummaryMapper.cs
+++ b/src/Esfa.Vacancy.Register.UnitTests/SearchApprenticeship/Api/Mappings/GivenApprenticeshipSummaryMapper.cs
@@ -62,8 +62,21 @@ namespace Esfa.Vacancy.Register.UnitTests.SearchApprenticeship.Api.Mappings
 
             var result = _mapper.Map<ApiTypes.ApprenticeshipSummary>(domainType);
 
-            result.ShortDescription.Should().Be(description, "Then map description to short description");
+            result.ShortDescription.Should().Be(description, "Then map Description to ShortDescription");
         }
 
+        [Test]
+        public void WhenMappingTrainingProviderName()
+        {
+            var providerName = "desc";
+            var domainType = new DomainTypes.ApprenticeshipSummary
+            {
+                ProviderName = providerName
+            };
+
+            var result = _mapper.Map<ApiTypes.ApprenticeshipSummary>(domainType);
+
+            result.TrainingProviderName.Should().Be(providerName, "Then map ProviderName to TrainingProviderName");
+        }
     }
 }

--- a/src/Esfa.Vacancy.Register.UnitTests/SearchApprenticeship/Api/Mappings/GivenApprenticeshipSummaryMapper.cs
+++ b/src/Esfa.Vacancy.Register.UnitTests/SearchApprenticeship/Api/Mappings/GivenApprenticeshipSummaryMapper.cs
@@ -21,7 +21,7 @@ namespace Esfa.Vacancy.Register.UnitTests.SearchApprenticeship.Api.Mappings
 
         [TestCase(1, null, ApiTypes.TrainingType.Standard, TestName = "Then load Standard type")]
         [TestCase(null, "10", ApiTypes.TrainingType.Framework, TestName = "Then load Framework type")]
-        public void ThenLoadCorrectTraingingDetails(int? standardId, string frameworkCode, ApiTypes.TrainingType expectedTrainingType)
+        public void WhenMappingTraingingDetails(int? standardId, string frameworkCode, ApiTypes.TrainingType expectedTrainingType)
         {
             var expectedTrainingCode = standardId.HasValue ? standardId.ToString() : frameworkCode;
             var domainType = new DomainTypes.ApprenticeshipSummary()
@@ -37,7 +37,7 @@ namespace Esfa.Vacancy.Register.UnitTests.SearchApprenticeship.Api.Mappings
         }
 
         [Test]
-        public void ThenLoadCorrectLocationGeoCoordinates()
+        public void WhenMappingGeoCoordinates()
         {
             var domainType = new DomainTypes.ApprenticeshipSummary
             {
@@ -46,9 +46,24 @@ namespace Esfa.Vacancy.Register.UnitTests.SearchApprenticeship.Api.Mappings
 
             var result = _mapper.Map<ApiTypes.ApprenticeshipSummary>(domainType);
 
-            result.Location.Latitude.Should().Be(51.3288148990m);
-            result.Location.Longitude.Should().Be(0.4452948632m);
+            result.Location.Latitude.Should().Be(51.3288148990m, "Then map latitude to Location");
+            result.Location.Longitude.Should().Be(0.4452948632m, "Then map longitude to Location");
 
         }
+
+        [Test]
+        public void WhenMappingShortDescription()
+        {
+            var description = "desc";
+            var domainType = new DomainTypes.ApprenticeshipSummary
+            {
+                Description = description
+            };
+
+            var result = _mapper.Map<ApiTypes.ApprenticeshipSummary>(domainType);
+
+            result.ShortDescription.Should().Be(description, "Then map description to short description");
+        }
+
     }
 }


### PR DESCRIPTION
Location type in detail's response was returning an integer which would make no sense to the consumers. Since search is enabled to list vacancies whose location is set as Nationwide, it just made more sense that response objects reflect if the vacancy is nationwide or not.