### PR TITLE
Fix/RA-1288 handle missed route

### DIFF
--- a/src/Esfa.Vacancy.Register.Api/App_Start/VacancyApiExceptionHandler.cs
+++ b/src/Esfa.Vacancy.Register.Api/App_Start/VacancyApiExceptionHandler.cs
@@ -61,16 +61,8 @@ namespace Esfa.Vacancy.Register.Api.App_Start
             catch
             {
                 //whatever happens don't leak the stack trace
-                context.Result = CreateStringResult(HttpStatusCode.InternalServerError, ExceptionInExceptionHandlerErrorMessage, context.Request);
+                context.Result = CreateResult(HttpStatusCode.InternalServerError, ExceptionInExceptionHandlerErrorMessage, context.Request);
             }
-        }
-
-        private IHttpActionResult CreateStringResult(HttpStatusCode statusCode, string content, HttpRequestMessage request)
-        {
-            var response = new HttpResponseMessage(statusCode);
-            response.Content = new StringContent(content);
-            var result = new CustomErrorResult(request, response);
-            return result;
         }
 
         private string FormatLogMessage(string message, ExceptionHandlerContext context)

--- a/src/Esfa.Vacancy.Register.Api/App_Start/VacancyApiExceptionHandler.cs
+++ b/src/Esfa.Vacancy.Register.Api/App_Start/VacancyApiExceptionHandler.cs
@@ -44,19 +44,19 @@ namespace Esfa.Vacancy.Register.Api.App_Start
                 if (context.Exception is ResourceNotFoundException)
                 {
                     _logger.Info(FormatLogMessage("Unable to locate resource error", context));
-                    context.Result = CreateStringResult(HttpStatusCode.NotFound, ((ResourceNotFoundException)context.Exception).Message, context.Request);
+                    context.Result = CreateResult(HttpStatusCode.NotFound, ((ResourceNotFoundException)context.Exception).Message, context.Request);
                     return;
                 }
 
                 if (context.Exception is InfrastructureException)
                 {
                     _logger.Error(context.Exception.InnerException, FormatLogMessage("Unexpected infrastructure error", context));
-                    context.Result = CreateStringResult(HttpStatusCode.InternalServerError, GenericErrorMessage, context.Request);
+                    context.Result = CreateResult(HttpStatusCode.InternalServerError, GenericErrorMessage, context.Request);
                     return;
                 }
 
                 _logger.Error(context.Exception, FormatLogMessage("Unexpected error", context));
-                context.Result = CreateStringResult(HttpStatusCode.InternalServerError, GenericErrorMessage, context.Request);
+                context.Result = CreateResult(HttpStatusCode.InternalServerError, GenericErrorMessage, context.Request);
             }
             catch
             {

--- a/src/Esfa.Vacancy.Register.Api/App_Start/VacancyApiExceptionHandler.cs
+++ b/src/Esfa.Vacancy.Register.Api/App_Start/VacancyApiExceptionHandler.cs
@@ -2,6 +2,7 @@
 using System.Net.Http;
 using System.Web.Http;
 using System.Web.Http.ExceptionHandling;
+using Esfa.Vacancy.Register.Api.Validation;
 using Esfa.Vacancy.Register.Application.Exceptions;
 using Esfa.Vacancy.Register.Infrastructure.Exceptions;
 using FluentValidation;

--- a/src/Esfa.Vacancy.Register.Api/App_Start/VacancyApiExceptionHandler.cs
+++ b/src/Esfa.Vacancy.Register.Api/App_Start/VacancyApiExceptionHandler.cs
@@ -37,7 +37,7 @@ namespace Esfa.Vacancy.Register.Api.App_Start
                 if (context.Exception is UnauthorisedException)
                 {
                     _logger.Warn(context.Exception, FormatLogMessage("Authorisation error", context));
-                    context.Result = CreateStringResult(HttpStatusCode.Unauthorized, ((UnauthorisedException)context.Exception).Message, context.Request);
+                    context.Result = CreateResult(HttpStatusCode.Unauthorized, ((UnauthorisedException)context.Exception).Message, context.Request);
                     return;
                 }
 
@@ -78,6 +78,12 @@ namespace Esfa.Vacancy.Register.Api.App_Start
             var requestUri = context.Request?.RequestUri?.ToString();
 
             return !string.IsNullOrEmpty(requestUri) ? $"{message} url:{requestUri}" : message;
+        }
+
+        private IHttpActionResult CreateResult(HttpStatusCode statusCode, string content, HttpRequestMessage request)
+        {
+            var response = request.CreateErrorResponse(statusCode, content);
+            return new CustomErrorResult(request, response);
         }
     }
 }

--- a/src/Esfa.Vacancy.Register.Api/Controllers/GetApprenticeshipVacancyController.cs
+++ b/src/Esfa.Vacancy.Register.Api/Controllers/GetApprenticeshipVacancyController.cs
@@ -41,6 +41,7 @@ namespace Esfa.Vacancy.Register.Api.Controllers
         /// | Error code  | Explanation                                                    |
         /// | ----------- | -------------------------------------------------------------- |
         /// | 30201       | Vacancy reference number must be greater than 0                |
+        /// | 30202       | Vacancy reference number must be a whole number                |
         /// 
         /// </summary>
         [HttpGet]

--- a/src/Esfa.Vacancy.Register.Api/Controllers/GetApprenticeshipVacancyController.cs
+++ b/src/Esfa.Vacancy.Register.Api/Controllers/GetApprenticeshipVacancyController.cs
@@ -1,6 +1,8 @@
 ﻿using System.Net;
+using System.Net.Http;
 using System.Threading.Tasks;
 using System.Web.Http;
+using System.Web.Http.Description;
 using Esfa.Vacancy.Api.Types;
 using Esfa.Vacancy.Register.Api.Constants;
 using Esfa.Vacancy.Register.Api.Orchestrators;
@@ -45,7 +47,7 @@ namespace Esfa.Vacancy.Register.Api.Controllers
         /// </summary>
         [HttpGet]
         [AllowAnonymous]
-        [Route("{vacancyReference:int}", Name = RouteName.GetApprenticeshipVacancyByReference)]
+        [Route("{vacancyReference:int}", Order = 0, Name = RouteName.GetApprenticeshipVacancyByReference)]
         [SwaggerOperation("GetApprenticeshipVacancy", Tags = new[] { "Apprenticeships" })]
         [SwaggerResponse(HttpStatusCode.OK, "OK", typeof(Vacancy.Api.Types.ApprenticeshipVacancy))]
         [SwaggerResponse(HttpStatusCode.BadRequest, "Failed request validation", typeof(BadRequestContent))]
@@ -54,6 +56,15 @@ namespace Esfa.Vacancy.Register.Api.Controllers
         {
             var vacancy = await _apprenticeshipVacancyOrchestrator.GetApprenticeshipVacancyDetailsAsync(vacancyReference);
             return Ok(vacancy);
+        }
+
+        [HttpGet]
+        [AllowAnonymous]
+        [Route("{wrongRoute}", Order = 1)]
+        [ApiExplorerSettings(IgnoreApi = true)]
+        public HttpResponseMessage Get(string wrongRoute)
+        {
+            return Request.CreateErrorResponse(HttpStatusCode.NotFound, "You have not searched by vacancy reference number.");
         }
     }
 }

--- a/src/Esfa.Vacancy.Register.Api/Controllers/GetApprenticeshipVacancyController.cs
+++ b/src/Esfa.Vacancy.Register.Api/Controllers/GetApprenticeshipVacancyController.cs
@@ -1,8 +1,6 @@
 ﻿using System.Net;
-using System.Net.Http;
 using System.Threading.Tasks;
 using System.Web.Http;
-using System.Web.Http.Description;
 using Esfa.Vacancy.Api.Types;
 using Esfa.Vacancy.Register.Api.Constants;
 using Esfa.Vacancy.Register.Api.Orchestrators;
@@ -47,24 +45,15 @@ namespace Esfa.Vacancy.Register.Api.Controllers
         /// </summary>
         [HttpGet]
         [AllowAnonymous]
-        [Route("{vacancyReference:int}", Order = 0, Name = RouteName.GetApprenticeshipVacancyByReference)]
+        [Route("{vacancyReference}", Name = RouteName.GetApprenticeshipVacancyByReference)]
         [SwaggerOperation("GetApprenticeshipVacancy", Tags = new[] { "Apprenticeships" })]
-        [SwaggerResponse(HttpStatusCode.OK, "OK", typeof(Vacancy.Api.Types.ApprenticeshipVacancy))]
+        [SwaggerResponse(HttpStatusCode.OK, "OK", typeof(ApprenticeshipVacancy))]
         [SwaggerResponse(HttpStatusCode.BadRequest, "Failed request validation", typeof(BadRequestContent))]
         [SwaggerResponse(HttpStatusCode.NotFound, "Vacancy not found or vacancy status is not Live")]
-        public async Task<IHttpActionResult> Get(int vacancyReference)
+        public async Task<IHttpActionResult> Get(string vacancyReference)
         {
             var vacancy = await _apprenticeshipVacancyOrchestrator.GetApprenticeshipVacancyDetailsAsync(vacancyReference);
             return Ok(vacancy);
-        }
-
-        [HttpGet]
-        [AllowAnonymous]
-        [Route("{wrongRoute}", Order = 1)]
-        [ApiExplorerSettings(IgnoreApi = true)]
-        public HttpResponseMessage Get(string wrongRoute)
-        {
-            return Request.CreateErrorResponse(HttpStatusCode.NotFound, "You have not searched by vacancy reference number.");
         }
     }
 }

--- a/src/Esfa.Vacancy.Register.Api/Controllers/GetTraineeshipVacancyController.cs
+++ b/src/Esfa.Vacancy.Register.Api/Controllers/GetTraineeshipVacancyController.cs
@@ -1,6 +1,8 @@
 ﻿using System.Net;
+using System.Net.Http;
 using System.Threading.Tasks;
 using System.Web.Http;
+using System.Web.Http.Description;
 using Esfa.Vacancy.Api.Types;
 using Esfa.Vacancy.Register.Api.Orchestrators;
 using Swashbuckle.Swagger.Annotations;
@@ -44,7 +46,7 @@ namespace Esfa.Vacancy.Register.Api.Controllers
         /// </summary>
         [HttpGet]
         [AllowAnonymous]
-        [Route("{vacancyReference:int}")]
+        [Route("{vacancyReference:int}", Order = 0)]
         [SwaggerOperation("GetTraineeshipVacancy", Tags = new[] { "Traineeships" })]
         [SwaggerResponse(HttpStatusCode.OK, "OK", typeof(Vacancy.Api.Types.TraineeshipVacancy))]
         [SwaggerResponse(HttpStatusCode.BadRequest, "Failed request validation", typeof(BadRequestContent))]
@@ -54,6 +56,15 @@ namespace Esfa.Vacancy.Register.Api.Controllers
             var vacancy = await _vacancyOrchestrator.GetTraineeshipVacancyDetailsAsync(vacancyReference);
 
             return Ok(vacancy);
+        }
+
+        [HttpGet]
+        [AllowAnonymous]
+        [Route("{wrongRoute}", Order = 1)]
+        [ApiExplorerSettings(IgnoreApi = true)]
+        public HttpResponseMessage Get(string wrongRoute)
+        {
+            return Request.CreateErrorResponse(HttpStatusCode.NotFound, "You have not searched by vacancy reference number.");
         }
     }
 }

--- a/src/Esfa.Vacancy.Register.Api/Controllers/GetTraineeshipVacancyController.cs
+++ b/src/Esfa.Vacancy.Register.Api/Controllers/GetTraineeshipVacancyController.cs
@@ -40,6 +40,7 @@ namespace Esfa.Vacancy.Register.Api.Controllers
         /// | Error code  | Explanation                                                    |
         /// | ----------- | -------------------------------------------------------------- |
         /// | 30401       | Vacancy reference number must be greater than 0                |
+        /// | 30402       | Vacancy reference number must be a whole number                |
         /// 
         /// </summary>
         [HttpGet]

--- a/src/Esfa.Vacancy.Register.Api/Controllers/GetTraineeshipVacancyController.cs
+++ b/src/Esfa.Vacancy.Register.Api/Controllers/GetTraineeshipVacancyController.cs
@@ -1,8 +1,6 @@
 ﻿using System.Net;
-using System.Net.Http;
 using System.Threading.Tasks;
 using System.Web.Http;
-using System.Web.Http.Description;
 using Esfa.Vacancy.Api.Types;
 using Esfa.Vacancy.Register.Api.Orchestrators;
 using Swashbuckle.Swagger.Annotations;
@@ -46,25 +44,16 @@ namespace Esfa.Vacancy.Register.Api.Controllers
         /// </summary>
         [HttpGet]
         [AllowAnonymous]
-        [Route("{vacancyReference:int}", Order = 0)]
+        [Route("{vacancyReference}")]
         [SwaggerOperation("GetTraineeshipVacancy", Tags = new[] { "Traineeships" })]
-        [SwaggerResponse(HttpStatusCode.OK, "OK", typeof(Vacancy.Api.Types.TraineeshipVacancy))]
+        [SwaggerResponse(HttpStatusCode.OK, "OK", typeof(TraineeshipVacancy))]
         [SwaggerResponse(HttpStatusCode.BadRequest, "Failed request validation", typeof(BadRequestContent))]
         [SwaggerResponse(HttpStatusCode.NotFound, "Vacancy not found or vacancy status is not Live")]
-        public async Task<IHttpActionResult> Get(int vacancyReference)
+        public async Task<IHttpActionResult> Get(string vacancyReference)
         {
             var vacancy = await _vacancyOrchestrator.GetTraineeshipVacancyDetailsAsync(vacancyReference);
 
             return Ok(vacancy);
-        }
-
-        [HttpGet]
-        [AllowAnonymous]
-        [Route("{wrongRoute}", Order = 1)]
-        [ApiExplorerSettings(IgnoreApi = true)]
-        public HttpResponseMessage Get(string wrongRoute)
-        {
-            return Request.CreateErrorResponse(HttpStatusCode.NotFound, "You have not searched by vacancy reference number.");
         }
     }
 }

--- a/src/Esfa.Vacancy.Register.Api/Controllers/GlobalErrorController.cs
+++ b/src/Esfa.Vacancy.Register.Api/Controllers/GlobalErrorController.cs
@@ -13,7 +13,7 @@ namespace Esfa.Vacancy.Register.Api.Controllers
         [ApiExplorerSettings(IgnoreApi = true)]
         public HttpResponseMessage Get()
         {
-            return Request.CreateErrorResponse(HttpStatusCode.BadRequest, "bad stuff");
+            return Request.CreateErrorResponse(HttpStatusCode.BadRequest, "There was a problem with your request.");
         }
     }
 }

--- a/src/Esfa.Vacancy.Register.Api/Controllers/GlobalErrorController.cs
+++ b/src/Esfa.Vacancy.Register.Api/Controllers/GlobalErrorController.cs
@@ -12,7 +12,13 @@ namespace Esfa.Vacancy.Register.Api.Controllers
         [ApiExplorerSettings(IgnoreApi = true)]
         public HttpResponseMessage Get()
         {
-            return Request.CreateErrorResponse(HttpStatusCode.BadRequest, "There was a problem with your request.");
+            try
+            {
+                return Request.CreateErrorResponse(HttpStatusCode.BadRequest, "There was a problem with your request.");
+            }
+            catch {}
+
+            return null;
         }
     }
 }

--- a/src/Esfa.Vacancy.Register.Api/Controllers/GlobalErrorController.cs
+++ b/src/Esfa.Vacancy.Register.Api/Controllers/GlobalErrorController.cs
@@ -2,11 +2,19 @@
 using System.Net.Http;
 using System.Web.Http;
 using System.Web.Http.Description;
+using SFA.DAS.NLog.Logger;
 
 namespace Esfa.Vacancy.Register.Api.Controllers
 {
     public class GlobalErrorController : ApiController
     {
+        private readonly ILog _logger;
+
+        public GlobalErrorController(ILog logger)
+        {
+            _logger = logger;
+        }
+
         [AllowAnonymous]
         [Route("api/error")]
         [ApiExplorerSettings(IgnoreApi = true)]
@@ -14,9 +22,13 @@ namespace Esfa.Vacancy.Register.Api.Controllers
         {
             try
             {
+                _logger.Warn("There was a problem with the request. Returning HTTP 400.");
                 return Request.CreateErrorResponse(HttpStatusCode.BadRequest, "There was a problem with your request.");
             }
-            catch {}
+            catch
+            {
+                // ignored
+            }
 
             return null;
         }

--- a/src/Esfa.Vacancy.Register.Api/Controllers/GlobalErrorController.cs
+++ b/src/Esfa.Vacancy.Register.Api/Controllers/GlobalErrorController.cs
@@ -1,0 +1,19 @@
+﻿using System.Net;
+using System.Net.Http;
+using System.Web.Http;
+using System.Web.Http.Description;
+
+namespace Esfa.Vacancy.Register.Api.Controllers
+{
+    public class GlobalErrorController : ApiController
+    {
+        [HttpGet]
+        [AllowAnonymous]
+        [Route("api/error")]
+        [ApiExplorerSettings(IgnoreApi = true)]
+        public HttpResponseMessage Get()
+        {
+            return Request.CreateErrorResponse(HttpStatusCode.BadRequest, "bad stuff");
+        }
+    }
+}

--- a/src/Esfa.Vacancy.Register.Api/Controllers/GlobalErrorController.cs
+++ b/src/Esfa.Vacancy.Register.Api/Controllers/GlobalErrorController.cs
@@ -7,7 +7,6 @@ namespace Esfa.Vacancy.Register.Api.Controllers
 {
     public class GlobalErrorController : ApiController
     {
-        [HttpGet]
         [AllowAnonymous]
         [Route("api/error")]
         [ApiExplorerSettings(IgnoreApi = true)]

--- a/src/Esfa.Vacancy.Register.Api/Esfa.Vacancy.Register.Api.csproj
+++ b/src/Esfa.Vacancy.Register.Api/Esfa.Vacancy.Register.Api.csproj
@@ -25,7 +25,6 @@
     <NuGetPackageImportStamp>
     </NuGetPackageImportStamp>
     <TargetFrameworkProfile />
-    <Use64BitIISExpress />
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>

--- a/src/Esfa.Vacancy.Register.Api/Esfa.Vacancy.Register.Api.csproj
+++ b/src/Esfa.Vacancy.Register.Api/Esfa.Vacancy.Register.Api.csproj
@@ -280,7 +280,9 @@
     <Content Include="Content\src\styles\govuk_template\assets\stylesheets\images\open-government-licence_2x.png" />
     <Content Include="Content\src\styles\govuk_template\views\layouts\govuk_template.html" />
     <Content Include="Global.asax" />
-    <Content Include="Web.config" />
+    <Content Include="Web.config">
+      <SubType>Designer</SubType>
+    </Content>
   </ItemGroup>
   <ItemGroup>
     <Compile Include="App_Start\AutoMapperConfig.cs" />
@@ -291,6 +293,7 @@
     <Compile Include="App_Start\StrictEnumConverter.cs" />
     <Compile Include="App_Start\ValidationBadRequestBuilder.cs" />
     <Compile Include="Constants\RouteName.cs" />
+    <Compile Include="Controllers\GlobalErrorController.cs" />
     <Compile Include="Controllers\GetTraineeshipVacancyController.cs" />
     <Compile Include="Controllers\SearchApprenticeshipVacanciesController.cs" />
     <Compile Include="Controllers\VersionController.cs" />

--- a/src/Esfa.Vacancy.Register.Api/Esfa.Vacancy.Register.Api.csproj
+++ b/src/Esfa.Vacancy.Register.Api/Esfa.Vacancy.Register.Api.csproj
@@ -327,6 +327,7 @@
     <Compile Include="Orchestrators\GetApprenticeshipVacancyOrchestrator.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Validation\IValidationBadRequestBuilder.cs" />
+    <Compile Include="Validation\IValidationExceptionBuilder.cs" />
     <Compile Include="Validation\ValidationBadRequestBuilder.cs" />
     <Compile Include="WebRole.cs" />
   </ItemGroup>

--- a/src/Esfa.Vacancy.Register.Api/Esfa.Vacancy.Register.Api.csproj
+++ b/src/Esfa.Vacancy.Register.Api/Esfa.Vacancy.Register.Api.csproj
@@ -297,6 +297,7 @@
     <Compile Include="Controllers\VersionController.cs" />
     <Compile Include="Mappings\AddressMapper.cs" />
     <Compile Include="Mappings\ApprenticeshipMapper.cs" />
+    <Compile Include="Mappings\IApprenticeshipMapper.cs" />
     <Compile Include="Mappings\IntToEnumConverter.cs" />
     <Compile Include="Mappings\TraineeshipMapper.cs" />
     <Compile Include="Mappings\ApprenticeshipSummaryMapper.cs" />

--- a/src/Esfa.Vacancy.Register.Api/Esfa.Vacancy.Register.Api.csproj
+++ b/src/Esfa.Vacancy.Register.Api/Esfa.Vacancy.Register.Api.csproj
@@ -329,6 +329,7 @@
     <Compile Include="Validation\IValidationBadRequestBuilder.cs" />
     <Compile Include="Validation\IValidationExceptionBuilder.cs" />
     <Compile Include="Validation\ValidationBadRequestBuilder.cs" />
+    <Compile Include="Validation\ValidationExceptionBuilder.cs" />
     <Compile Include="WebRole.cs" />
   </ItemGroup>
   <ItemGroup>

--- a/src/Esfa.Vacancy.Register.Api/Esfa.Vacancy.Register.Api.csproj
+++ b/src/Esfa.Vacancy.Register.Api/Esfa.Vacancy.Register.Api.csproj
@@ -25,6 +25,7 @@
     <NuGetPackageImportStamp>
     </NuGetPackageImportStamp>
     <TargetFrameworkProfile />
+    <Use64BitIISExpress />
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -285,12 +286,10 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="App_Start\AutoMapperConfig.cs" />
-    <Compile Include="App_Start\IValidationBadRequestBuilder.cs" />
     <Compile Include="App_Start\VacancyApiExceptionHandler.cs" />
     <Compile Include="App_Start\CustomErrorResult.cs" />
     <Compile Include="App_Start\ApiFilterConfig.cs" />
     <Compile Include="App_Start\StrictEnumConverter.cs" />
-    <Compile Include="App_Start\ValidationBadRequestBuilder.cs" />
     <Compile Include="Constants\RouteName.cs" />
     <Compile Include="Controllers\GlobalErrorController.cs" />
     <Compile Include="Controllers\GetTraineeshipVacancyController.cs" />
@@ -326,6 +325,8 @@
     <Compile Include="Orchestrators\SearchApprenticeshipVacanciesOrchestrator.cs" />
     <Compile Include="Orchestrators\GetApprenticeshipVacancyOrchestrator.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="Validation\IValidationBadRequestBuilder.cs" />
+    <Compile Include="Validation\ValidationBadRequestBuilder.cs" />
     <Compile Include="WebRole.cs" />
   </ItemGroup>
   <ItemGroup>

--- a/src/Esfa.Vacancy.Register.Api/Esfa.Vacancy.Register.Api.csproj
+++ b/src/Esfa.Vacancy.Register.Api/Esfa.Vacancy.Register.Api.csproj
@@ -299,6 +299,7 @@
     <Compile Include="Mappings\ApprenticeshipMapper.cs" />
     <Compile Include="Mappings\IApprenticeshipMapper.cs" />
     <Compile Include="Mappings\IntToEnumConverter.cs" />
+    <Compile Include="Mappings\ITraineeshipMapper.cs" />
     <Compile Include="Mappings\TraineeshipMapper.cs" />
     <Compile Include="Mappings\ApprenticeshipSummaryMapper.cs" />
     <Compile Include="Models\VersionInformation.cs" />

--- a/src/Esfa.Vacancy.Register.Api/Global.asax.cs
+++ b/src/Esfa.Vacancy.Register.Api/Global.asax.cs
@@ -25,5 +25,26 @@ namespace Esfa.Vacancy.Register.Api
         {
             HttpContext.Current?.Response.Headers.Remove("Server");
         }
+
+        protected void Application_Error(object sender, EventArgs e)
+        {
+            var ex = Server.GetLastError();
+            var req = Request;
+            var res = Response;
+
+            if (!(ex is HttpException httpError)) return;
+
+            if (Request.Path.StartsWith("api/"))
+            {
+                Response.Redirect("api/DangerousRequest");
+            }
+            else
+            {
+                Response.Redirect("/DangerousRequest");
+            }
+
+            var logger = DependencyResolver.Current.GetService<ILog>();
+            logger.Error(httpError, httpError.Message);
+        }
     }
 }

--- a/src/Esfa.Vacancy.Register.Api/Global.asax.cs
+++ b/src/Esfa.Vacancy.Register.Api/Global.asax.cs
@@ -28,16 +28,22 @@ namespace Esfa.Vacancy.Register.Api
 
         protected void Application_Error(object sender, EventArgs e)
         {
-            var ex = Server.GetLastError();
-
-            if (ex is HttpException httpError)
+            try
             {
-                ApiRedirect("~/api/error");
-                return;
-            }
+                var ex = Server.GetLastError();
 
-            var logger = DependencyResolver.Current.GetService<ILog>();
-            if (ex != null) logger.Warn(ex, ex.Message);
+                var logger = DependencyResolver.Current.GetService<ILog>();
+                if (ex != null) logger.Warn(ex, ex.Message);
+
+                if (ex is HttpException)
+                {
+                    ApiRedirect("~/api/error");
+                }
+            }
+            catch
+            {
+                // ignored
+            }
         }
 
         private void ApiRedirect(string path)

--- a/src/Esfa.Vacancy.Register.Api/Global.asax.cs
+++ b/src/Esfa.Vacancy.Register.Api/Global.asax.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.EnterpriseServices;
 using System.Web;
 using System.Web.Http;
 using System.Web.Mvc;
@@ -29,22 +30,22 @@ namespace Esfa.Vacancy.Register.Api
         protected void Application_Error(object sender, EventArgs e)
         {
             var ex = Server.GetLastError();
-            var req = Request;
-            var res = Response;
 
-            if (!(ex is HttpException httpError)) return;
-
-            if (Request.Path.StartsWith("api/"))
+            if (ex is HttpException httpError)
             {
-                Response.Redirect("api/DangerousRequest");
-            }
-            else
-            {
-                Response.Redirect("/DangerousRequest");
+                ApiRedirect("~/api/error");
+                return;
             }
 
             var logger = DependencyResolver.Current.GetService<ILog>();
-            logger.Error(httpError, httpError.Message);
+            if (ex != null) logger.Warn(ex, ex.Message);
+        }
+
+        private void ApiRedirect(string path)
+        {
+            Response.Clear();
+            Server.ClearError();
+            Context.RewritePath(path, false);
         }
     }
 }

--- a/src/Esfa.Vacancy.Register.Api/Global.asax.cs
+++ b/src/Esfa.Vacancy.Register.Api/Global.asax.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.EnterpriseServices;
 using System.Web;
 using System.Web.Http;
 using System.Web.Mvc;

--- a/src/Esfa.Vacancy.Register.Api/Mappings/ApprenticeshipMapper.cs
+++ b/src/Esfa.Vacancy.Register.Api/Mappings/ApprenticeshipMapper.cs
@@ -7,7 +7,7 @@ using DomainEntities = Esfa.Vacancy.Register.Domain.Entities;
 
 namespace Esfa.Vacancy.Register.Api.Mappings
 {
-    public sealed class ApprenticeshipMapper
+    public sealed class ApprenticeshipMapper : IApprenticeshipMapper
     {
         private readonly IProvideSettings _provideSettings;
         private readonly AddressMapper _addressMapper = new AddressMapper();

--- a/src/Esfa.Vacancy.Register.Api/Mappings/IApprenticeshipMapper.cs
+++ b/src/Esfa.Vacancy.Register.Api/Mappings/IApprenticeshipMapper.cs
@@ -1,0 +1,9 @@
+﻿using Esfa.Vacancy.Api.Types;
+
+namespace Esfa.Vacancy.Register.Api.Mappings
+{
+    public interface IApprenticeshipMapper
+    {
+        ApprenticeshipVacancy MapToApprenticeshipVacancy(Domain.Entities.ApprenticeshipVacancy apprenticeshipVacancy);
+    }
+}

--- a/src/Esfa.Vacancy.Register.Api/Mappings/ITraineeshipMapper.cs
+++ b/src/Esfa.Vacancy.Register.Api/Mappings/ITraineeshipMapper.cs
@@ -1,0 +1,9 @@
+﻿using Esfa.Vacancy.Api.Types;
+
+namespace Esfa.Vacancy.Register.Api.Mappings
+{
+    public interface ITraineeshipMapper
+    {
+        TraineeshipVacancy MapToTraineeshipVacancy(Domain.Entities.TraineeshipVacancy traineeshipVacancy);
+    }
+}

--- a/src/Esfa.Vacancy.Register.Api/Mappings/TraineeshipMapper.cs
+++ b/src/Esfa.Vacancy.Register.Api/Mappings/TraineeshipMapper.cs
@@ -3,7 +3,7 @@ using TraineeshipVacancy = Esfa.Vacancy.Api.Types.TraineeshipVacancy;
 
 namespace Esfa.Vacancy.Register.Api.Mappings
 {
-    public sealed class TraineeshipMapper
+    public sealed class TraineeshipMapper : ITraineeshipMapper
     {
         private readonly IProvideSettings _provideSettings;
         private readonly AddressMapper _addressMapper = new AddressMapper();

--- a/src/Esfa.Vacancy.Register.Api/Orchestrators/GetApprenticeshipVacancyOrchestrator.cs
+++ b/src/Esfa.Vacancy.Register.Api/Orchestrators/GetApprenticeshipVacancyOrchestrator.cs
@@ -1,7 +1,7 @@
 using System.Threading.Tasks;
 using Esfa.Vacancy.Register.Api.Mappings;
 using Esfa.Vacancy.Register.Application.Queries.GetApprenticeshipVacancy;
-using Esfa.Vacancy.Register.Infrastructure.Settings;
+using FluentValidation;
 using MediatR;
 
 namespace Esfa.Vacancy.Register.Api.Orchestrators
@@ -9,17 +9,23 @@ namespace Esfa.Vacancy.Register.Api.Orchestrators
     public class GetApprenticeshipVacancyOrchestrator
     {
         private readonly IMediator _mediator;
-        private readonly ApprenticeshipMapper _mapper;
+        private readonly IApprenticeshipMapper _mapper;
 
-        public GetApprenticeshipVacancyOrchestrator(IMediator mediator, IProvideSettings provideSettings)
+        public GetApprenticeshipVacancyOrchestrator(IMediator mediator, IApprenticeshipMapper apprenticeshipMapper)
         {
             _mediator = mediator;
-            _mapper = new ApprenticeshipMapper(provideSettings);
+            _mapper = apprenticeshipMapper;
         }
 
         public async Task<Vacancy.Api.Types.ApprenticeshipVacancy> GetApprenticeshipVacancyDetailsAsync(string id)
         {
-            var response = await _mediator.Send(new GetApprenticeshipVacancyRequest() { Reference = 3 });
+            int parsedId;
+            if (!int.TryParse(id, out parsedId))
+            {
+                throw new ValidationException("todo");
+            }
+
+            var response = await _mediator.Send(new GetApprenticeshipVacancyRequest() { Reference = parsedId });
             var vacancy = _mapper.MapToApprenticeshipVacancy(response.ApprenticeshipVacancy);
 
             return vacancy;

--- a/src/Esfa.Vacancy.Register.Api/Orchestrators/GetApprenticeshipVacancyOrchestrator.cs
+++ b/src/Esfa.Vacancy.Register.Api/Orchestrators/GetApprenticeshipVacancyOrchestrator.cs
@@ -17,9 +17,9 @@ namespace Esfa.Vacancy.Register.Api.Orchestrators
             _mapper = new ApprenticeshipMapper(provideSettings);
         }
 
-        public async Task<Vacancy.Api.Types.ApprenticeshipVacancy> GetApprenticeshipVacancyDetailsAsync(int id)
+        public async Task<Vacancy.Api.Types.ApprenticeshipVacancy> GetApprenticeshipVacancyDetailsAsync(string id)
         {
-            var response = await _mediator.Send(new GetApprenticeshipVacancyRequest() { Reference = id });
+            var response = await _mediator.Send(new GetApprenticeshipVacancyRequest() { Reference = 3 });
             var vacancy = _mapper.MapToApprenticeshipVacancy(response.ApprenticeshipVacancy);
 
             return vacancy;

--- a/src/Esfa.Vacancy.Register.Api/Orchestrators/GetApprenticeshipVacancyOrchestrator.cs
+++ b/src/Esfa.Vacancy.Register.Api/Orchestrators/GetApprenticeshipVacancyOrchestrator.cs
@@ -1,7 +1,8 @@
 using System.Threading.Tasks;
 using Esfa.Vacancy.Register.Api.Mappings;
+using Esfa.Vacancy.Register.Api.Validation;
 using Esfa.Vacancy.Register.Application.Queries.GetApprenticeshipVacancy;
-using FluentValidation;
+using Esfa.Vacancy.Register.Domain.Validation;
 using MediatR;
 
 namespace Esfa.Vacancy.Register.Api.Orchestrators
@@ -10,11 +11,13 @@ namespace Esfa.Vacancy.Register.Api.Orchestrators
     {
         private readonly IMediator _mediator;
         private readonly IApprenticeshipMapper _mapper;
+        private readonly IValidationExceptionBuilder _validationExceptionBuilder;
 
-        public GetApprenticeshipVacancyOrchestrator(IMediator mediator, IApprenticeshipMapper apprenticeshipMapper)
+        public GetApprenticeshipVacancyOrchestrator(IMediator mediator, IApprenticeshipMapper apprenticeshipMapper, IValidationExceptionBuilder validationExceptionBuilder)
         {
             _mediator = mediator;
             _mapper = apprenticeshipMapper;
+            _validationExceptionBuilder = validationExceptionBuilder;
         }
 
         public async Task<Vacancy.Api.Types.ApprenticeshipVacancy> GetApprenticeshipVacancyDetailsAsync(string id)
@@ -22,7 +25,9 @@ namespace Esfa.Vacancy.Register.Api.Orchestrators
             int parsedId;
             if (!int.TryParse(id, out parsedId))
             {
-                throw new ValidationException("todo");
+                throw _validationExceptionBuilder.Build(
+                    ErrorCodes.GetApprenticeship.VacancyReferenceNumberNotInt32, 
+                    ErrorMessages.GetApprenticeship.VacancyReferenceNumberNotNumeric);
             }
 
             var response = await _mediator.Send(new GetApprenticeshipVacancyRequest() { Reference = parsedId });

--- a/src/Esfa.Vacancy.Register.Api/Orchestrators/GetTraineeshipVacancyOrchestrator.cs
+++ b/src/Esfa.Vacancy.Register.Api/Orchestrators/GetTraineeshipVacancyOrchestrator.cs
@@ -31,8 +31,9 @@ namespace Esfa.Vacancy.Register.Api.Orchestrators
                     ErrorMessages.GetTraineeship.VacancyReferenceNumberNotNumeric);
             }
 
-            var response = await _mediator.Send(new GetTraineeshipVacancyRequest() { Reference = -1 });
+            var response = await _mediator.Send(new GetTraineeshipVacancyRequest() { Reference = parsedId });
             var vacancy = _mapper.MapToTraineeshipVacancy(response.TraineeshipVacancy);
+
             return vacancy;
         }
     }

--- a/src/Esfa.Vacancy.Register.Api/Orchestrators/GetTraineeshipVacancyOrchestrator.cs
+++ b/src/Esfa.Vacancy.Register.Api/Orchestrators/GetTraineeshipVacancyOrchestrator.cs
@@ -1,7 +1,9 @@
 ﻿using System.Threading.Tasks;
 using Esfa.Vacancy.Api.Types;
 using Esfa.Vacancy.Register.Api.Mappings;
+using Esfa.Vacancy.Register.Api.Validation;
 using Esfa.Vacancy.Register.Application.Queries.GetTraineeshipVacancy;
+using Esfa.Vacancy.Register.Domain.Validation;
 using MediatR;
 
 namespace Esfa.Vacancy.Register.Api.Orchestrators
@@ -10,16 +12,26 @@ namespace Esfa.Vacancy.Register.Api.Orchestrators
     {
         private readonly IMediator _mediator;
         private readonly ITraineeshipMapper _mapper;
+        private readonly IValidationExceptionBuilder _validationExceptionBuilder;
 
-        public GetTraineeshipVacancyOrchestrator(IMediator mediator, ITraineeshipMapper mapper)
+        public GetTraineeshipVacancyOrchestrator(IMediator mediator, ITraineeshipMapper mapper, IValidationExceptionBuilder validationExceptionBuilder)
         {
             _mediator = mediator;
             _mapper = mapper;
+            _validationExceptionBuilder = validationExceptionBuilder;
         }
 
-        public async Task<TraineeshipVacancy> GetTraineeshipVacancyDetailsAsync(int id)
+        public async Task<TraineeshipVacancy> GetTraineeshipVacancyDetailsAsync(string id)
         {
-            var response = await _mediator.Send(new GetTraineeshipVacancyRequest() { Reference = id });
+            int parsedId;
+            if (!int.TryParse(id, out parsedId))
+            {
+                throw _validationExceptionBuilder.Build(
+                    ErrorCodes.GetTraineeship.VacancyReferenceNumberNotInt32,
+                    ErrorMessages.GetTraineeship.VacancyReferenceNumberNotNumeric);
+            }
+
+            var response = await _mediator.Send(new GetTraineeshipVacancyRequest() { Reference = -1 });
             var vacancy = _mapper.MapToTraineeshipVacancy(response.TraineeshipVacancy);
             return vacancy;
         }

--- a/src/Esfa.Vacancy.Register.Api/Orchestrators/GetTraineeshipVacancyOrchestrator.cs
+++ b/src/Esfa.Vacancy.Register.Api/Orchestrators/GetTraineeshipVacancyOrchestrator.cs
@@ -2,7 +2,6 @@
 using Esfa.Vacancy.Api.Types;
 using Esfa.Vacancy.Register.Api.Mappings;
 using Esfa.Vacancy.Register.Application.Queries.GetTraineeshipVacancy;
-using Esfa.Vacancy.Register.Infrastructure.Settings;
 using MediatR;
 
 namespace Esfa.Vacancy.Register.Api.Orchestrators
@@ -10,12 +9,12 @@ namespace Esfa.Vacancy.Register.Api.Orchestrators
     public class GetTraineeshipVacancyOrchestrator
     {
         private readonly IMediator _mediator;
-        private readonly TraineeshipMapper _mapper;
+        private readonly ITraineeshipMapper _mapper;
 
-        public GetTraineeshipVacancyOrchestrator(IMediator mediator, IProvideSettings provideSettings)
+        public GetTraineeshipVacancyOrchestrator(IMediator mediator, ITraineeshipMapper mapper)
         {
             _mediator = mediator;
-            _mapper = new TraineeshipMapper(provideSettings);
+            _mapper = mapper;
         }
 
         public async Task<TraineeshipVacancy> GetTraineeshipVacancyDetailsAsync(int id)

--- a/src/Esfa.Vacancy.Register.Api/Orchestrators/SearchApprenticeshipVacanciesOrchestrator.cs
+++ b/src/Esfa.Vacancy.Register.Api/Orchestrators/SearchApprenticeshipVacanciesOrchestrator.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
 using System.Threading.Tasks;
 using AutoMapper;
 using Esfa.Vacancy.Api.Types;
@@ -7,14 +6,13 @@ using Esfa.Vacancy.Register.Api.Validation;
 using Esfa.Vacancy.Register.Application.Queries.SearchApprenticeshipVacancies;
 using Esfa.Vacancy.Register.Domain.Validation;
 using Esfa.Vacancy.Register.Infrastructure.Settings;
-using FluentValidation;
-using FluentValidation.Results;
 using MediatR;
 
 namespace Esfa.Vacancy.Register.Api.Orchestrators
 {
     public class SearchApprenticeshipVacanciesOrchestrator
     {
+        private const string ApprenticeSearchPropertyName = "apprenticeSearchParameters";
         private readonly IMediator _mediator;
         private readonly IMapper _mapper;
         private readonly IProvideSettings _provideSettings;
@@ -40,7 +38,7 @@ namespace Esfa.Vacancy.Register.Api.Orchestrators
                 throw _validationExceptionBuilder.Build(
                     ErrorCodes.SearchApprenticeships.SearchApprenticeshipParametersIsNull,
                     ErrorMessages.SearchApprenticeships.SearchApprenticeshipParametersIsNull,
-                    "apprenticeSearchParameters");
+                    ApprenticeSearchPropertyName);
             }
 
             var request = _mapper.Map<SearchApprenticeshipVacanciesRequest>(apprenticeSearchParameters);

--- a/src/Esfa.Vacancy.Register.Api/Validation/IValidationBadRequestBuilder.cs
+++ b/src/Esfa.Vacancy.Register.Api/Validation/IValidationBadRequestBuilder.cs
@@ -2,7 +2,7 @@
 using System.Web.Http;
 using FluentValidation;
 
-namespace Esfa.Vacancy.Register.Api.App_Start
+namespace Esfa.Vacancy.Register.Api.Validation
 {
     public interface IValidationBadRequestBuilder
     {

--- a/src/Esfa.Vacancy.Register.Api/Validation/IValidationExceptionBuilder.cs
+++ b/src/Esfa.Vacancy.Register.Api/Validation/IValidationExceptionBuilder.cs
@@ -1,0 +1,9 @@
+using FluentValidation;
+
+namespace Esfa.Vacancy.Register.Api.Validation
+{
+    public interface IValidationExceptionBuilder
+    {
+        ValidationException Build(string errorCode, string errorMessage, string propertyName = "default");
+    }
+}

--- a/src/Esfa.Vacancy.Register.Api/Validation/ValidationBadRequestBuilder.cs
+++ b/src/Esfa.Vacancy.Register.Api/Validation/ValidationBadRequestBuilder.cs
@@ -3,9 +3,10 @@ using System.Net;
 using System.Net.Http;
 using System.Web.Http;
 using Esfa.Vacancy.Api.Types;
+using Esfa.Vacancy.Register.Api.App_Start;
 using FluentValidation;
 
-namespace Esfa.Vacancy.Register.Api.App_Start
+namespace Esfa.Vacancy.Register.Api.Validation
 {
     public class ValidationBadRequestBuilder : IValidationBadRequestBuilder
     {

--- a/src/Esfa.Vacancy.Register.Api/Validation/ValidationExceptionBuilder.cs
+++ b/src/Esfa.Vacancy.Register.Api/Validation/ValidationExceptionBuilder.cs
@@ -1,0 +1,17 @@
+﻿using System.Collections.Generic;
+using FluentValidation;
+using FluentValidation.Results;
+
+namespace Esfa.Vacancy.Register.Api.Validation
+{
+    public class ValidationExceptionBuilder : IValidationExceptionBuilder
+    {
+        public ValidationException Build(string errorCode, string errorMessage, string propertyName = "default")
+        {
+            return new ValidationException(new List<ValidationFailure>()
+            {
+                new ValidationFailure(propertyName, errorMessage){ErrorCode = errorCode}
+            });
+        }
+    }
+}

--- a/src/Esfa.Vacancy.Register.Api/Web.config
+++ b/src/Esfa.Vacancy.Register.Api/Web.config
@@ -81,6 +81,7 @@
       <remove name="ApplicationInsightsWebTracking" />
       <add name="ApplicationInsightsWebTracking" type="Microsoft.ApplicationInsights.Web.ApplicationInsightsHttpModule, Microsoft.AI.Web" preCondition="managedHandler" />
     </modules>
+    <httpErrors existingResponse="PassThrough" />
   </system.webServer>
   <nlog xsi:schemaLocation="http://www.nlog-project.org/schemas/NLog.xsd NLog.xsd" autoReload="true" throwExceptions="false" internalLogLevel="Debug" internalLogFile="c:\temp\nlog-internal.${appName}.log" xmlns="http://www.nlog-project.org/schemas/NLog.xsd" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
     <extensions>

--- a/src/Esfa.Vacancy.Register.Application/Queries/GetApprenticeshipVacancy/GetApprenticeshipVacancyQueryHandler.cs
+++ b/src/Esfa.Vacancy.Register.Application/Queries/GetApprenticeshipVacancy/GetApprenticeshipVacancyQueryHandler.cs
@@ -10,7 +10,7 @@ namespace Esfa.Vacancy.Register.Application.Queries.GetApprenticeshipVacancy
 {
     public class GetApprenticeshipVacancyQueryHandler : IAsyncRequestHandler<GetApprenticeshipVacancyRequest, GetApprenticeshipVacancyResponse>
     {
-        private const string VacancyNotFoundErrorMessage = "The apprenticeship vacancy you are looking for cannot be found.";
+        private const string VacancyNotFoundErrorMessage = "The apprenticeship vacancy you are looking for could not be found.";
         private readonly AbstractValidator<GetApprenticeshipVacancyRequest> _validator;
         private readonly IVacancyRepository _vacancyRepository;
         private readonly ILog _logger;

--- a/src/Esfa.Vacancy.Register.Application/Queries/GetApprenticeshipVacancy/GetApprenticeshipVacancyQueryHandler.cs
+++ b/src/Esfa.Vacancy.Register.Application/Queries/GetApprenticeshipVacancy/GetApprenticeshipVacancyQueryHandler.cs
@@ -10,6 +10,7 @@ namespace Esfa.Vacancy.Register.Application.Queries.GetApprenticeshipVacancy
 {
     public class GetApprenticeshipVacancyQueryHandler : IAsyncRequestHandler<GetApprenticeshipVacancyRequest, GetApprenticeshipVacancyResponse>
     {
+        private const string VacancyNotFoundErrorMessage = "The apprenticeship vacancy you are looking for cannot be found.";
         private readonly AbstractValidator<GetApprenticeshipVacancyRequest> _validator;
         private readonly IVacancyRepository _vacancyRepository;
         private readonly ILog _logger;
@@ -37,7 +38,7 @@ namespace Esfa.Vacancy.Register.Application.Queries.GetApprenticeshipVacancy
 
             var vacancy = await _vacancyRepository.GetApprenticeshipVacancyByReferenceNumberAsync(message.Reference);
 
-            if (vacancy == null) throw new ResourceNotFoundException();
+            if (vacancy == null) throw new ResourceNotFoundException(VacancyNotFoundErrorMessage);
 
             if (vacancy.FrameworkCode.HasValue)
             {

--- a/src/Esfa.Vacancy.Register.Application/Queries/GetTraineeshipVacancy/GetTraineeshipVacancyQueryHandler.cs
+++ b/src/Esfa.Vacancy.Register.Application/Queries/GetTraineeshipVacancy/GetTraineeshipVacancyQueryHandler.cs
@@ -9,6 +9,7 @@ namespace Esfa.Vacancy.Register.Application.Queries.GetTraineeshipVacancy
 {
     public sealed class GetTraineeshipVacancyQueryHandler : IAsyncRequestHandler<GetTraineeshipVacancyRequest, GetTraineeshipVacancyResponse>
     {
+        private const string VacancyNotFoundErrorMessage = "The traineeship vacancy you are looking for cannot be found.";
         private readonly AbstractValidator<GetTraineeshipVacancyRequest> _validator;
         private readonly IVacancyRepository _vacancyRepository;
         private readonly ILog _logger;
@@ -33,7 +34,7 @@ namespace Esfa.Vacancy.Register.Application.Queries.GetTraineeshipVacancy
 
             var vacancy = await _vacancyRepository.GetTraineeshipVacancyByReferenceNumberAsync(message.Reference);
 
-            if (vacancy == null) throw new ResourceNotFoundException();
+            if (vacancy == null) throw new ResourceNotFoundException(VacancyNotFoundErrorMessage);
 
             return new GetTraineeshipVacancyResponse { TraineeshipVacancy = vacancy };
         }

--- a/src/Esfa.Vacancy.Register.Application/Queries/GetTraineeshipVacancy/GetTraineeshipVacancyQueryHandler.cs
+++ b/src/Esfa.Vacancy.Register.Application/Queries/GetTraineeshipVacancy/GetTraineeshipVacancyQueryHandler.cs
@@ -9,7 +9,7 @@ namespace Esfa.Vacancy.Register.Application.Queries.GetTraineeshipVacancy
 {
     public sealed class GetTraineeshipVacancyQueryHandler : IAsyncRequestHandler<GetTraineeshipVacancyRequest, GetTraineeshipVacancyResponse>
     {
-        private const string VacancyNotFoundErrorMessage = "The traineeship vacancy you are looking for cannot be found.";
+        private const string VacancyNotFoundErrorMessage = "The traineeship vacancy you are looking for could not be found.";
         private readonly AbstractValidator<GetTraineeshipVacancyRequest> _validator;
         private readonly IVacancyRepository _vacancyRepository;
         private readonly ILog _logger;

--- a/src/Esfa.Vacancy.Register.Domain/Validation/ErrorCodes.cs
+++ b/src/Esfa.Vacancy.Register.Domain/Validation/ErrorCodes.cs
@@ -29,6 +29,7 @@
         {
             // 30200 - 30299
             public const string VacancyReferenceNumberLessThan0         = "30201";
+            public const string VacancyReferenceNumberNotInt32          = "30202";
         }
 
         public static class SearchTraineeships

--- a/src/Esfa.Vacancy.Register.Domain/Validation/ErrorCodes.cs
+++ b/src/Esfa.Vacancy.Register.Domain/Validation/ErrorCodes.cs
@@ -41,6 +41,7 @@
         {
             // 30400 - 30499
             public const string VacancyReferenceNumberLessThan0         = "30401";
+            public const string VacancyReferenceNumberNotInt32          = "30402";
         }
     }
 }

--- a/src/Esfa.Vacancy.Register.Domain/Validation/ErrorMessages.cs
+++ b/src/Esfa.Vacancy.Register.Domain/Validation/ErrorMessages.cs
@@ -19,5 +19,10 @@ namespace Esfa.Vacancy.Register.Domain.Validation
             public static string GetGeoLocationFieldNotProvidedErrorMessage(string fieldName) =>
                 $"When searching by geo-location 'Latitude', 'Longitude' and 'DistanceInMiles' are required. You have not provided '{fieldName}'.";
         }
+
+        public static class GetApprenticeship
+        {
+            public const string VacancyReferenceNumberNotNumeric = "The vacancy reference number must be numeric.";
+        }
     }
 }

--- a/src/Esfa.Vacancy.Register.Domain/Validation/ErrorMessages.cs
+++ b/src/Esfa.Vacancy.Register.Domain/Validation/ErrorMessages.cs
@@ -24,5 +24,10 @@ namespace Esfa.Vacancy.Register.Domain.Validation
         {
             public const string VacancyReferenceNumberNotNumeric = "The vacancy reference number must be numeric.";
         }
+
+        public static class GetTraineeship
+        {
+            public const string VacancyReferenceNumberNotNumeric = "The vacancy reference number must be numeric.";
+        }
     }
 }

--- a/src/Esfa.Vacancy.Register.UnitTests/Esfa.Vacancy.Register.UnitTests.csproj
+++ b/src/Esfa.Vacancy.Register.UnitTests/Esfa.Vacancy.Register.UnitTests.csproj
@@ -123,6 +123,7 @@
     <Compile Include="SearchApprenticeship\Application\GivenAVacancySearchParametersMapper\AndLocationFields.cs" />
     <Compile Include="SearchApprenticeship\Domain\GivenAVacancySearchParameters\WhenCallingHasGeoSearchFields.cs" />
     <Compile Include="SearchApprenticeship\Domain\GivenAVacancySearchParameters\WhenCallingToString.cs" />
+    <Compile Include="Shared\Api\Validation\GivenAValidationExceptionBuilder.cs" />
     <Compile Include="Shared\Infrastructure\GivenACachedFrameworkCodeRepository\WhenCallingGetAsync.cs" />
     <Compile Include="Shared\Infrastructure\GivenACachedStandardRepository\WhenCallingGetStandardIdsAsync.cs" />
     <Compile Include="SearchApprenticeship\Application\GivenAVacancySearchParametersMapper\AndFrameworkLarsCodes.cs" />

--- a/src/Esfa.Vacancy.Register.UnitTests/Esfa.Vacancy.Register.UnitTests.csproj
+++ b/src/Esfa.Vacancy.Register.UnitTests/Esfa.Vacancy.Register.UnitTests.csproj
@@ -79,11 +79,11 @@
       <HintPath>..\packages\NUnit.3.7.1\lib\net45\nunit.framework.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Ploeh.AutoFixture, Version=3.51.0.0, Culture=neutral, PublicKeyToken=b24654c590009d4f, processorArchitecture=MSIL">
-      <HintPath>..\packages\AutoFixture.3.51.0\lib\net40\Ploeh.AutoFixture.dll</HintPath>
+    <Reference Include="Ploeh.AutoFixture, Version=3.50.0.0, Culture=neutral, PublicKeyToken=b24654c590009d4f, processorArchitecture=MSIL">
+      <HintPath>..\packages\AutoFixture.3.50.6\lib\net40\Ploeh.AutoFixture.dll</HintPath>
     </Reference>
-    <Reference Include="Ploeh.AutoFixture.AutoMoq, Version=3.51.0.0, Culture=neutral, PublicKeyToken=b24654c590009d4f, processorArchitecture=MSIL">
-      <HintPath>..\packages\AutoFixture.AutoMoq.3.51.0\lib\net40\Ploeh.AutoFixture.AutoMoq.dll</HintPath>
+    <Reference Include="Ploeh.AutoFixture.AutoMoq, Version=3.50.0.0, Culture=neutral, PublicKeyToken=b24654c590009d4f, processorArchitecture=MSIL">
+      <HintPath>..\packages\AutoFixture.AutoMoq.3.50.6\lib\net40\Ploeh.AutoFixture.AutoMoq.dll</HintPath>
     </Reference>
     <Reference Include="Polly, Version=5.3.1.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\packages\Polly.5.3.1\lib\net45\Polly.dll</HintPath>

--- a/src/Esfa.Vacancy.Register.UnitTests/Esfa.Vacancy.Register.UnitTests.csproj
+++ b/src/Esfa.Vacancy.Register.UnitTests/Esfa.Vacancy.Register.UnitTests.csproj
@@ -79,9 +79,11 @@
       <HintPath>..\packages\NUnit.3.7.1\lib\net45\nunit.framework.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Ploeh.AutoFixture, Version=3.50.0.0, Culture=neutral, PublicKeyToken=b24654c590009d4f, processorArchitecture=MSIL">
-      <HintPath>..\packages\AutoFixture.3.50.6\lib\net40\Ploeh.AutoFixture.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="Ploeh.AutoFixture, Version=3.51.0.0, Culture=neutral, PublicKeyToken=b24654c590009d4f, processorArchitecture=MSIL">
+      <HintPath>..\packages\AutoFixture.3.51.0\lib\net40\Ploeh.AutoFixture.dll</HintPath>
+    </Reference>
+    <Reference Include="Ploeh.AutoFixture.AutoMoq, Version=3.51.0.0, Culture=neutral, PublicKeyToken=b24654c590009d4f, processorArchitecture=MSIL">
+      <HintPath>..\packages\AutoFixture.AutoMoq.3.51.0\lib\net40\Ploeh.AutoFixture.AutoMoq.dll</HintPath>
     </Reference>
     <Reference Include="Polly, Version=5.3.1.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\packages\Polly.5.3.1\lib\net45\Polly.dll</HintPath>

--- a/src/Esfa.Vacancy.Register.UnitTests/GetApprenticeshipVacancy/Api/Orchestrators/GivenAGetApprenticeshipVacancyOrchestrator/WhenGettingLiveApprenticeship.cs
+++ b/src/Esfa.Vacancy.Register.UnitTests/GetApprenticeshipVacancy/Api/Orchestrators/GivenAGetApprenticeshipVacancyOrchestrator/WhenGettingLiveApprenticeship.cs
@@ -49,7 +49,7 @@ namespace Esfa.Vacancy.Register.UnitTests.GetApprenticeshipVacancy.Api.Orchestra
                                             .Create()
                 });
 
-            var result = await _sut.GetApprenticeshipVacancyDetailsAsync(VacancyReference);
+            var result = await _sut.GetApprenticeshipVacancyDetailsAsync(VacancyReference.ToString());
 
             result.VacancyReference.Should().Be(VacancyReference);
             result.EmployerName.Should().Be("ABC Ltd");
@@ -86,7 +86,7 @@ namespace Esfa.Vacancy.Register.UnitTests.GetApprenticeshipVacancy.Api.Orchestra
                                             .Create()
                 });
 
-            var result = await _sut.GetApprenticeshipVacancyDetailsAsync(VacancyReference);
+            var result = await _sut.GetApprenticeshipVacancyDetailsAsync(VacancyReference.ToString());
 
             result.VacancyReference.Should().Be(VacancyReference);
             result.EmployerName.Should().Be("ABC Ltd");
@@ -124,7 +124,7 @@ namespace Esfa.Vacancy.Register.UnitTests.GetApprenticeshipVacancy.Api.Orchestra
 
             var sut = new GetApprenticeshipVacancyOrchestrator(_mockMediator.Object, _provideSettings.Object);
             //Act
-            var vacancy = await sut.GetApprenticeshipVacancyDetailsAsync(12345);
+            var vacancy = await sut.GetApprenticeshipVacancyDetailsAsync("12345");
 
             //Assert
             Assert.AreEqual($"{baseUrl}/{VacancyReference}", vacancy.VacancyUrl);

--- a/src/Esfa.Vacancy.Register.UnitTests/GetApprenticeshipVacancy/Api/Orchestrators/GivenAGetApprenticeshipVacancyOrchestrator/WhenGettingLiveApprenticeship.cs
+++ b/src/Esfa.Vacancy.Register.UnitTests/GetApprenticeshipVacancy/Api/Orchestrators/GivenAGetApprenticeshipVacancyOrchestrator/WhenGettingLiveApprenticeship.cs
@@ -163,6 +163,7 @@ namespace Esfa.Vacancy.Register.UnitTests.GetApprenticeshipVacancy.Api.Orchestra
                 .ReturnsAsync(response);
 
             var sut = new GetApprenticeshipVacancyOrchestrator(_mockMediator.Object, new ApprenticeshipMapper(provideSettings.Object), _fixture.Create<IValidationExceptionBuilder>());
+            
             //Act
             var vacancy = await sut.GetApprenticeshipVacancyDetailsAsync("12345");
 

--- a/src/Esfa.Vacancy.Register.UnitTests/GetTraineeshipVacancy/Api/Orchestrators/GivenAGetTraineeshipVacancyOrchestrator/WhenGettingLiveTraineeship.cs
+++ b/src/Esfa.Vacancy.Register.UnitTests/GetTraineeshipVacancy/Api/Orchestrators/GivenAGetTraineeshipVacancyOrchestrator/WhenGettingLiveTraineeship.cs
@@ -26,7 +26,6 @@ namespace Esfa.Vacancy.Register.UnitTests.GetTraineeshipVacancy.Api.Orchestrator
         private const int VacancyReference = 1234;
         private const int LiveVacancyStatusId = 2;
         private Mock<IMediator> _mockMediator;
-        private Mock<IProvideSettings> _mockProvideSettings;
         private GetTraineeshipVacancyOrchestrator _sut;
         private IFixture _fixture;
         private string _expectedErrorMessage;
@@ -52,6 +51,18 @@ namespace Esfa.Vacancy.Register.UnitTests.GetTraineeshipVacancy.Api.Orchestrator
             ));
 
             _sut = _fixture.Create<GetTraineeshipVacancyOrchestrator>();
+        }
+
+        [Test]
+        public async Task ThenCreatesGetApprenticeshipVacancyRequestWithRefNumber()
+        {
+            var uniqueVacancyRef = _fixture.Create<int>();
+            await _sut.GetTraineeshipVacancyDetailsAsync(uniqueVacancyRef.ToString());
+
+            _mockMediator.Verify(mediator =>
+                mediator.Send(
+                    It.Is<GetTraineeshipVacancyRequest>(request => request.Reference == uniqueVacancyRef),
+                    CancellationToken.None));
         }
 
         [Test]

--- a/src/Esfa.Vacancy.Register.UnitTests/Shared/Api/App_Start/GivenAVacancyApiExceptionHandler.cs
+++ b/src/Esfa.Vacancy.Register.UnitTests/Shared/Api/App_Start/GivenAVacancyApiExceptionHandler.cs
@@ -113,10 +113,7 @@ namespace Esfa.Vacancy.Register.UnitTests.Shared.Api.App_Start
         [Test]
         public async Task AndUnauthorisedExceptionIsThrownThenReturnUnauthorized()
         {
-            var context = new ExceptionHandlerContext(new ExceptionContext(
-                new UnauthorisedException("no access"),
-                new ExceptionContextCatchBlock("name", true, true),
-                new HttpRequestMessage()));
+            var context = BuildNewContext(new UnauthorisedException("no access"));
 
             _handler.Handle(context);
 
@@ -124,16 +121,13 @@ namespace Esfa.Vacancy.Register.UnitTests.Shared.Api.App_Start
 
             _logger.Verify(l => l.Warn(It.IsAny<UnauthorisedException>(), "Authorisation error"), Times.Once);
             message.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
-            message.Content.ReadAsStringAsync().Result.Should().Be("no access");
+            message.Content.ReadAsStringAsync().Result.Should().Be("{\"Message\":\"no access\"}");
         }
 
         [Test]
         public async Task AndResourceNotFoundExceptionIsThrownThenReturnNotFound()
         {
-            var context = new ExceptionHandlerContext(new ExceptionContext(
-                new ResourceNotFoundException("no resource"),
-                new ExceptionContextCatchBlock("name", true, true),
-                new HttpRequestMessage()));
+            var context = BuildNewContext(new ResourceNotFoundException("no resource"));
 
             _handler.Handle(context);
 
@@ -147,10 +141,7 @@ namespace Esfa.Vacancy.Register.UnitTests.Shared.Api.App_Start
         [Test]
         public async Task AndInfrastructureExceptionIsThrownThenReturnInternalServerError()
         {
-            var context = new ExceptionHandlerContext(new ExceptionContext(
-                new InfrastructureException(new Exception("an infrastructure error")),
-                new ExceptionContextCatchBlock("name", true, true),
-                new HttpRequestMessage()));
+            var context = BuildNewContext(new InfrastructureException(new Exception("an infrastructure error")));
 
             _handler.Handle(context);
 
@@ -164,11 +155,7 @@ namespace Esfa.Vacancy.Register.UnitTests.Shared.Api.App_Start
         [Test]
         public async Task AndExceptionIsThrownThenReturnInternalServerError()
         {
-            var context = new ExceptionHandlerContext(new ExceptionContext(
-                new Exception("an infrastructure error"),
-                new ExceptionContextCatchBlock("name", true, true),
-                new HttpRequestMessage())
-                );
+            var context = BuildNewContext(new Exception("an infrastructure error"));
 
             _handler.Handle(context);
 
@@ -195,5 +182,13 @@ namespace Esfa.Vacancy.Register.UnitTests.Shared.Api.App_Start
             _logger.Verify(l => l.Error(It.IsAny<Exception>(), "Unexpected infrastructure error url:http://resource/that/errored"), Times.Once);
         }
 
+        private static ExceptionHandlerContext BuildNewContext<T>(T exception) where T : Exception
+        {
+            return new ExceptionHandlerContext(new ExceptionContext(
+                exception,
+                new ExceptionContextCatchBlock("name", true, true),
+                new Mock<HttpRequestMessage>().Object)
+            );
+        }
     }
 }

--- a/src/Esfa.Vacancy.Register.UnitTests/Shared/Api/App_Start/GivenAVacancyApiExceptionHandler.cs
+++ b/src/Esfa.Vacancy.Register.UnitTests/Shared/Api/App_Start/GivenAVacancyApiExceptionHandler.cs
@@ -10,6 +10,7 @@ using System.Web.Http.Dependencies;
 using System.Web.Http.ExceptionHandling;
 using Esfa.Vacancy.Api.Types;
 using Esfa.Vacancy.Register.Api.App_Start;
+using Esfa.Vacancy.Register.Api.Validation;
 using Esfa.Vacancy.Register.Application.Exceptions;
 using Esfa.Vacancy.Register.Infrastructure.Exceptions;
 using FluentAssertions;

--- a/src/Esfa.Vacancy.Register.UnitTests/Shared/Api/App_Start/GivenAVacancyApiExceptionHandler.cs
+++ b/src/Esfa.Vacancy.Register.UnitTests/Shared/Api/App_Start/GivenAVacancyApiExceptionHandler.cs
@@ -135,7 +135,7 @@ namespace Esfa.Vacancy.Register.UnitTests.Shared.Api.App_Start
 
             _logger.Verify(l => l.Info("Unable to locate resource error"), Times.Once);
             message.StatusCode.Should().Be(HttpStatusCode.NotFound);
-            message.Content.ReadAsStringAsync().Result.Should().Be("no resource");
+            message.Content.ReadAsStringAsync().Result.Should().Be("{\"Message\":\"no resource\"}");
         }
 
         [Test]
@@ -149,7 +149,7 @@ namespace Esfa.Vacancy.Register.UnitTests.Shared.Api.App_Start
 
             _logger.Verify(l => l.Error(It.IsAny<Exception>(), "Unexpected infrastructure error"), Times.Once);
             message.StatusCode.Should().Be(HttpStatusCode.InternalServerError);
-            message.Content.ReadAsStringAsync().Result.Should().Be(GenericErrorMessage);
+            message.Content.ReadAsStringAsync().Result.Should().Be($"{{\"Message\":\"{GenericErrorMessage}\"}}");
         }
 
         [Test]
@@ -163,7 +163,7 @@ namespace Esfa.Vacancy.Register.UnitTests.Shared.Api.App_Start
 
             _logger.Verify(l => l.Error(It.IsAny<Exception>(), "Unexpected error"), Times.Once);
             message.StatusCode.Should().Be(HttpStatusCode.InternalServerError);
-            message.Content.ReadAsStringAsync().Result.Should().Be(GenericErrorMessage);
+            message.Content.ReadAsStringAsync().Result.Should().Be($"{{\"Message\":\"{GenericErrorMessage}\"}}");
         }
 
         [Test]

--- a/src/Esfa.Vacancy.Register.UnitTests/Shared/Api/App_Start/GivenAVacancyApiExceptionHandler.cs
+++ b/src/Esfa.Vacancy.Register.UnitTests/Shared/Api/App_Start/GivenAVacancyApiExceptionHandler.cs
@@ -61,7 +61,7 @@ namespace Esfa.Vacancy.Register.UnitTests.Shared.Api.App_Start
             var message = await context.Result.ExecuteAsync(CancellationToken.None);
 
             message.StatusCode.Should().Be(HttpStatusCode.InternalServerError);
-            message.Content.ReadAsStringAsync().Result.Should().Be(ExceptionInExceptionHandlerErrorMessage);
+            message.Content.ReadAsStringAsync().Result.Should().Be($"{{\"Message\":\"{ExceptionInExceptionHandlerErrorMessage}\"}}");
         }
 
         [Test]

--- a/src/Esfa.Vacancy.Register.UnitTests/Shared/Api/Validation/GivenAValidationExceptionBuilder.cs
+++ b/src/Esfa.Vacancy.Register.UnitTests/Shared/Api/Validation/GivenAValidationExceptionBuilder.cs
@@ -1,0 +1,63 @@
+﻿using System.Linq;
+using Esfa.Vacancy.Register.Api.Validation;
+using FluentAssertions;
+using FluentValidation;
+using NUnit.Framework;
+using Ploeh.AutoFixture;
+
+namespace Esfa.Vacancy.Register.UnitTests.Shared.Api.Validation
+{
+    [TestFixture]
+    public class GivenAValidationExceptionBuilder
+    {
+        private string _expectedErrorCode;
+        private string _expectedErrorMessage;
+        private string _expectedPropertyName;
+        private ValidationException _exception;
+        private ValidationException _exceptionWithPropertyName;
+
+        [SetUp]
+        public void WhenCallingBuild()
+        {
+            var fixture = new Fixture();
+
+            _expectedErrorCode = fixture.Create<string>();
+            _expectedErrorMessage = fixture.Create<string>();
+            _expectedPropertyName = fixture.Create<string>();
+            var builder = fixture.Create<ValidationExceptionBuilder>();
+
+            _exception = builder.Build(_expectedErrorCode, _expectedErrorMessage);
+            _exceptionWithPropertyName = builder.Build(_expectedErrorCode, _expectedErrorMessage, _expectedPropertyName);
+        }
+
+        [Test]
+        public void ThenErrorsCountShouldBeOne()
+        {
+            _exception.Errors.ToList().Count.Should().Be(1);
+        }
+
+        [Test]
+        public void ThenItShouldPopulateTheErrorCode()
+        {
+            _exception.Errors.ToList()[0].ErrorCode.Should().Be(_expectedErrorCode);
+        }
+
+        [Test]
+        public void ThenItShouldPopulateTheErrorMessage()
+        {
+            _exception.Errors.ToList()[0].ErrorMessage.Should().Be(_expectedErrorMessage);
+        }
+
+        [Test]
+        public void ThenItShouldPopulateThePropertyNameAsDefault()
+        {
+            _exception.Errors.ToList()[0].PropertyName.Should().Be("default");
+        }
+
+        [Test]
+        public void AndPropertyNameProvided_ThenItShouldPopulateTheProperty()
+        {
+            _exceptionWithPropertyName.Errors.ToList()[0].PropertyName.Should().Be(_expectedPropertyName);
+        }
+    }
+}

--- a/src/Esfa.Vacancy.Register.UnitTests/app.config
+++ b/src/Esfa.Vacancy.Register.UnitTests/app.config
@@ -18,10 +18,6 @@
         <assemblyIdentity name="System.Net.Http.Formatting" publicKeyToken="31bf3856ad364e35" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-5.2.3.0" newVersion="5.2.3.0" />
       </dependentAssembly>
-      <dependentAssembly>
-        <assemblyIdentity name="Moq" publicKeyToken="69f491c39445e920" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-4.7.63.0" newVersion="4.7.63.0" />
-      </dependentAssembly>
     </assemblyBinding>
   </runtime>
 </configuration>

--- a/src/Esfa.Vacancy.Register.UnitTests/app.config
+++ b/src/Esfa.Vacancy.Register.UnitTests/app.config
@@ -18,6 +18,10 @@
         <assemblyIdentity name="System.Net.Http.Formatting" publicKeyToken="31bf3856ad364e35" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-5.2.3.0" newVersion="5.2.3.0" />
       </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="Moq" publicKeyToken="69f491c39445e920" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.7.63.0" newVersion="4.7.63.0" />
+      </dependentAssembly>
     </assemblyBinding>
   </runtime>
 </configuration>

--- a/src/Esfa.Vacancy.Register.UnitTests/packages.config
+++ b/src/Esfa.Vacancy.Register.UnitTests/packages.config
@@ -1,6 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="AutoFixture" version="3.50.6" targetFramework="net452" />
+  <package id="AutoFixture" version="3.51.0" targetFramework="net452" />
+  <package id="AutoFixture.AutoMoq" version="3.51.0" targetFramework="net452" />
   <package id="AutoMapper" version="6.1.1" targetFramework="net452" />
   <package id="Castle.Core" version="4.1.0" targetFramework="net452" />
   <package id="Elasticsearch.Net" version="1.9.2" targetFramework="net452" />

--- a/src/Esfa.Vacancy.Register.UnitTests/packages.config
+++ b/src/Esfa.Vacancy.Register.UnitTests/packages.config
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="AutoFixture" version="3.51.0" targetFramework="net452" />
-  <package id="AutoFixture.AutoMoq" version="3.51.0" targetFramework="net452" />
+  <package id="AutoFixture" version="3.50.6" targetFramework="net452" />
+  <package id="AutoFixture.AutoMoq" version="3.50.6" targetFramework="net452" />
   <package id="AutoMapper" version="6.1.1" targetFramework="net452" />
   <package id="Castle.Core" version="4.1.0" targetFramework="net452" />
   <package id="Elasticsearch.Net" version="1.9.2" targetFramework="net452" />


### PR DESCRIPTION
## RA-1288
Handles missing route,
404
400
except for route/% which is still kicked out by IIS.
https://blogs.iis.net/nazim/use-of-special-characters-like-in-an-iis-url
`<httpErrors existingResponse="PassThrough" />` added to enable global.asax to reformat some error responses.

## RA-1386 

- Updated get endpoints for apprenticeship and traineeship
- Uses shared validation exception builder, also retrofitted this to search orchestrator