### PR TITLE
Feature/RA-1357 valid search param combos

### DIFF
--- a/src/Esfa.Vacancy.Application/Queries/SearchApprenticeshipVacancies/SearchApprenticeshipVacanciesRequestValidator.cs
+++ b/src/Esfa.Vacancy.Application/Queries/SearchApprenticeshipVacancies/SearchApprenticeshipVacanciesRequestValidator.cs
@@ -33,6 +33,8 @@ namespace Esfa.Vacancy.Application.Queries.SearchApprenticeshipVacancies
             RuleFor(request => request.StandardLarsCodes)
                 .NotEmpty()
                 .When(request => !request.FrameworkLarsCodes.Any())
+                .When(request => !request.NationwideOnly)
+                .When(request => !request.PostedInLastNumberOfDays.HasValue)
                 .WithMessage(ErrorMessages.SearchApprenticeships.StandardAndFrameworkCodeNotProvided)
                 .WithErrorCode(ErrorCodes.SearchApprenticeships.StandardAndFrameworkCodeNotProvided);
 

--- a/src/Esfa.Vacancy.Application/Queries/SearchApprenticeshipVacancies/SearchApprenticeshipVacanciesRequestValidator.cs
+++ b/src/Esfa.Vacancy.Application/Queries/SearchApprenticeshipVacancies/SearchApprenticeshipVacanciesRequestValidator.cs
@@ -36,8 +36,8 @@ namespace Esfa.Vacancy.Application.Queries.SearchApprenticeshipVacancies
                 .When(request => !request.NationwideOnly)
                 .When(request => !request.PostedInLastNumberOfDays.HasValue)
                 .When(request => !request.Latitude.HasValue && !request.Longitude.HasValue && !request.DistanceInMiles.HasValue)
-                .WithMessage(ErrorMessages.SearchApprenticeships.StandardAndFrameworkCodeNotProvided)
-                .WithErrorCode(ErrorCodes.SearchApprenticeships.StandardAndFrameworkCodeNotProvided);
+                .WithMessage(ErrorMessages.SearchApprenticeships.MinimumRequiredFieldsNotProvided)
+                .WithErrorCode(ErrorCodes.SearchApprenticeships.MinimumRequiredFieldsNotProvided);
 
             RuleForEach(request => request.StandardLarsCodes)
                 .Must(BeValidNumber)

--- a/src/Esfa.Vacancy.Application/Queries/SearchApprenticeshipVacancies/SearchApprenticeshipVacanciesRequestValidator.cs
+++ b/src/Esfa.Vacancy.Application/Queries/SearchApprenticeshipVacancies/SearchApprenticeshipVacanciesRequestValidator.cs
@@ -39,6 +39,12 @@ namespace Esfa.Vacancy.Application.Queries.SearchApprenticeshipVacancies
                 .WithMessage(ErrorMessages.SearchApprenticeships.MinimumRequiredFieldsNotProvided)
                 .WithErrorCode(ErrorCodes.SearchApprenticeships.MinimumRequiredFieldsNotProvided);
 
+            RuleFor(request => request.NationwideOnly)
+                .NotEqual(true)
+                .When(request => request.Latitude.HasValue || request.Longitude.HasValue || request.DistanceInMiles.HasValue)
+                .WithMessage(ErrorMessages.SearchApprenticeships.GeoSearchAndNationwideNotAllowed)
+                .WithErrorCode(ErrorCodes.SearchApprenticeships.GeoSearchAndNationwideNotAllowed);
+
             RuleForEach(request => request.StandardLarsCodes)
                 .Must(BeValidNumber)
                 .WithMessage((request, value) =>

--- a/src/Esfa.Vacancy.Application/Queries/SearchApprenticeshipVacancies/SearchApprenticeshipVacanciesRequestValidator.cs
+++ b/src/Esfa.Vacancy.Application/Queries/SearchApprenticeshipVacancies/SearchApprenticeshipVacanciesRequestValidator.cs
@@ -35,6 +35,7 @@ namespace Esfa.Vacancy.Application.Queries.SearchApprenticeshipVacancies
                 .When(request => !request.FrameworkLarsCodes.Any())
                 .When(request => !request.NationwideOnly)
                 .When(request => !request.PostedInLastNumberOfDays.HasValue)
+                .When(request => !request.Latitude.HasValue && !request.Longitude.HasValue && !request.DistanceInMiles.HasValue)
                 .WithMessage(ErrorMessages.SearchApprenticeships.StandardAndFrameworkCodeNotProvided)
                 .WithErrorCode(ErrorCodes.SearchApprenticeships.StandardAndFrameworkCodeNotProvided);
 

--- a/src/Esfa.Vacancy.Domain/Validation/ErrorCodes.cs
+++ b/src/Esfa.Vacancy.Domain/Validation/ErrorCodes.cs
@@ -7,7 +7,7 @@
             // 30100 - 30199
             public const string SearchApprenticeshipParametersIsNull    = "30100";
 
-            public const string StandardAndFrameworkCodeNotProvided     = "30101";
+            public const string MinimumRequiredFieldsNotProvided        = "30101";
             public const string StandardCodeNotInt32                    = "30102";
             public const string FrameworkCodeNotInt32                   = "30103";
             public const string PageSizeOutsideRange                    = "30104";

--- a/src/Esfa.Vacancy.Domain/Validation/ErrorCodes.cs
+++ b/src/Esfa.Vacancy.Domain/Validation/ErrorCodes.cs
@@ -23,6 +23,7 @@
             public const string LongitudeOutsideRange                   = "30112";
             public const string DistanceMissingFromGeoSearch            = "30113";
             public const string DistanceOutsideRange                    = "30114";
+            public const string GeoSearchAndNationwideNotAllowed        = "30115";
         }
 
         public static class GetApprenticeship

--- a/src/Esfa.Vacancy.Domain/Validation/ErrorMessages.cs
+++ b/src/Esfa.Vacancy.Domain/Validation/ErrorMessages.cs
@@ -8,7 +8,7 @@ namespace Esfa.Vacancy.Domain.Validation
         {
             public const string SearchApprenticeshipParametersIsNull = "At least one search parameter is required.";
 
-            public const string StandardAndFrameworkCodeNotProvided = "At least one of the Standard or Framework code is required.";
+            public const string MinimumRequiredFieldsNotProvided = "At least one of Standard code, Framework code, NationwideOnly, PostedInLastNumberOfDays or Geo-location fields is required.";
 
             public static string GetTrainingCodeNotFoundErrorMessage(TrainingType trainingType, string code) =>
                 $"{trainingType} code {code} not found.";

--- a/src/Esfa.Vacancy.Domain/Validation/ErrorMessages.cs
+++ b/src/Esfa.Vacancy.Domain/Validation/ErrorMessages.cs
@@ -18,6 +18,8 @@ namespace Esfa.Vacancy.Domain.Validation
 
             public static string GetGeoLocationFieldNotProvidedErrorMessage(string fieldName) =>
                 $"When searching by geo-location 'Latitude', 'Longitude' and 'DistanceInMiles' are required. You have not provided '{fieldName}'.";
+
+            public const string GeoSearchAndNationwideNotAllowed = "Searching by geo-location and national vacancies is not a valid combination.";
         }
 
         public static class GetApprenticeship

--- a/src/Esfa.Vacancy.Register.Api/Controllers/SearchApprenticeshipVacanciesController.cs
+++ b/src/Esfa.Vacancy.Register.Api/Controllers/SearchApprenticeshipVacanciesController.cs
@@ -82,23 +82,24 @@ namespace Esfa.Vacancy.Register.Api.Controllers
         /// The following error codes may be returned when calling this operation if any of the search criteria values 
         /// specified fail validation:
         /// 
-        /// | Error code  | Explanation                                                    |
-        /// | ----------- | -------------------------------------------------------------- |
-        /// | 30100       | Search parameters were not specified                           |
-        /// | 30101       | At least 1 standard *or* framework code must be specified      |
-        /// | 30102       | Standard code must be a number                                 |
-        /// | 30103       | Framework code must be a number                                |
-        /// | 30104       | Page size must be between 1 and 250 (inclusive)                |
-        /// | 30105       | Page number must be greater than 0                             |
-        /// | 30106       | Number of days since posted must be greater than or equal to 0 |
-        /// | 30107       | Framework code not recognised                                  |
-        /// | 30108       | Standard code not recognised                                   |
-        /// | 30109       | Latitude is required when performing geo-search                |
-        /// | 30110       | Latitude must be between -90 and 90 (inclusive)                |
-        /// | 30111       | Longitude is required when performing geo-search               |
-        /// | 30112       | Longitude must be between -180 and 180 (inclusive)             |
-        /// | 30113       | Distance in miles is required when performing geo-search       |
-        /// | 30114       | Distance in miles must be between 1 and 1000 (inclusive)       |
+        /// | Error code  | Explanation                                                                 |
+        /// | ----------- | --------------------------------------------------------------------------- |
+        /// | 30100       | Search parameters were not specified                                        |
+        /// | 30101       | At least 1 standard *or* framework code must be specified                   |
+        /// | 30102       | Standard code must be a number                                              |
+        /// | 30103       | Framework code must be a number                                             |
+        /// | 30104       | Page size must be between 1 and 250 (inclusive)                             |
+        /// | 30105       | Page number must be greater than 0                                          |
+        /// | 30106       | Number of days since posted must be greater than or equal to 0              |
+        /// | 30107       | Framework code not recognised                                               |
+        /// | 30108       | Standard code not recognised                                                |
+        /// | 30109       | Latitude is required when performing geo-search                             |
+        /// | 30110       | Latitude must be between -90 and 90 (inclusive)                             |
+        /// | 30111       | Longitude is required when performing geo-search                            |
+        /// | 30112       | Longitude must be between -180 and 180 (inclusive)                          |
+        /// | 30113       | Distance in miles is required when performing geo-search                    |
+        /// | 30114       | Distance in miles must be between 1 and 1000 (inclusive)                    |
+        /// | 30115       | Searching by geo-location and national vacancies is not a valid combination |
         /// 
         /// </summary>
         [HttpGet]

--- a/src/Esfa.Vacancy.UnitTests/Esfa.Vacancy.UnitTests.csproj
+++ b/src/Esfa.Vacancy.UnitTests/Esfa.Vacancy.UnitTests.csproj
@@ -124,6 +124,7 @@
     <Compile Include="SearchApprenticeship\Api\Mappings\GivenASearchApprenticeshipParametersMapper\WhenMappingLatitude.cs" />
     <Compile Include="GetTraineeshipVacancy\Api\Mappings\GivenTraineeshipMapper.cs" />
     <Compile Include="SearchApprenticeship\Application\GivenASearchApprenticeshipVacanciesRequestValidator\WhenValidatingDistanceInMiles.cs" />
+    <Compile Include="SearchApprenticeship\Application\GivenASearchApprenticeshipVacanciesRequestValidator\WhenValidatingGeoLocationAndNationwide.cs" />
     <Compile Include="SearchApprenticeship\Application\GivenASearchApprenticeshipVacanciesRequestValidator\WhenValidatingLongitude.cs" />
     <Compile Include="SearchApprenticeship\Application\GivenASearchApprenticeshipVacanciesRequestValidator\WhenValidatingLatitude.cs" />
     <Compile Include="SearchApprenticeship\Application\GivenASearchApprenticeshipVacanciesRequestValidator\WhenValidatingGeoSearchFields.cs" />

--- a/src/Esfa.Vacancy.UnitTests/SearchApprenticeship/Application/GivenASearchApprenticeshipVacanciesRequestValidator/WhenValidatingDistanceInMiles.cs
+++ b/src/Esfa.Vacancy.UnitTests/SearchApprenticeship/Application/GivenASearchApprenticeshipVacanciesRequestValidator/WhenValidatingDistanceInMiles.cs
@@ -15,7 +15,6 @@ namespace Esfa.Vacancy.UnitTests.SearchApprenticeship.Application.GivenASearchAp
         {
             new TestCaseData(new SearchApprenticeshipVacanciesRequest
                 {
-                    StandardLarsCodes = ValidStandardCodes,
                     Latitude = 52.399085,
                     Longitude = -1.506115,
                     DistanceInMiles = 235
@@ -23,7 +22,6 @@ namespace Esfa.Vacancy.UnitTests.SearchApprenticeship.Application.GivenASearchAp
                 .SetName("And between 1 and 1000"),
             new TestCaseData(new SearchApprenticeshipVacanciesRequest
                 {
-                    StandardLarsCodes = ValidStandardCodes,
                     Latitude = 45,
                     Longitude = -18,
                     DistanceInMiles = 1
@@ -31,7 +29,6 @@ namespace Esfa.Vacancy.UnitTests.SearchApprenticeship.Application.GivenASearchAp
                 .SetName("And 1 then valid"),
             new TestCaseData(new SearchApprenticeshipVacanciesRequest
                 {
-                    StandardLarsCodes = ValidStandardCodes,
                     Latitude = 45,
                     Longitude = -18,
                     DistanceInMiles = 1000
@@ -39,7 +36,6 @@ namespace Esfa.Vacancy.UnitTests.SearchApprenticeship.Application.GivenASearchAp
                 .SetName("And 1000 then valid"),
             new TestCaseData(new SearchApprenticeshipVacanciesRequest
                 {
-                    StandardLarsCodes = ValidStandardCodes,
                     Latitude = 45,
                     Longitude = -18,
                     DistanceInMiles = 0
@@ -53,7 +49,6 @@ namespace Esfa.Vacancy.UnitTests.SearchApprenticeship.Application.GivenASearchAp
                 .SetName("And less than 1 then invalid"),
             new TestCaseData(new SearchApprenticeshipVacanciesRequest
                 {
-                    StandardLarsCodes = ValidStandardCodes,
                     Latitude = 45,
                     Longitude = -18,
                     DistanceInMiles = 1001

--- a/src/Esfa.Vacancy.UnitTests/SearchApprenticeship/Application/GivenASearchApprenticeshipVacanciesRequestValidator/WhenValidatingFrameworkCodes.cs
+++ b/src/Esfa.Vacancy.UnitTests/SearchApprenticeship/Application/GivenASearchApprenticeshipVacanciesRequestValidator/WhenValidatingFrameworkCodes.cs
@@ -11,7 +11,7 @@ namespace Esfa.Vacancy.UnitTests.SearchApprenticeship.Application.GivenASearchAp
     [TestFixture]
     public class WhenValidatingFrameworkCodes : GivenSearchApprenticeshipVacanciesRequestValidatorBase
     {
-        public static List<TestCaseData> SuccessTestCases => new List<TestCaseData>
+        private static List<TestCaseData> SuccessTestCases => new List<TestCaseData>
         {
             new TestCaseData(ValidFrameworkCodes)
                 .SetName("Then any number is valid"),
@@ -33,7 +33,7 @@ namespace Esfa.Vacancy.UnitTests.SearchApprenticeship.Application.GivenASearchAp
             result.IsValid.Should().BeTrue();
         }
 
-        public static List<TestCaseData> FailingTestCases => new List<TestCaseData>
+        private static List<TestCaseData> FailingTestCases => new List<TestCaseData>
         {
             new TestCaseData("e",
                 ErrorMessages.SearchApprenticeships.GetTrainingCodeShouldBeNumberErrorMessage(TrainingType.Framework, "e"),

--- a/src/Esfa.Vacancy.UnitTests/SearchApprenticeship/Application/GivenASearchApprenticeshipVacanciesRequestValidator/WhenValidatingGeoLocationAndNationwide.cs
+++ b/src/Esfa.Vacancy.UnitTests/SearchApprenticeship/Application/GivenASearchApprenticeshipVacanciesRequestValidator/WhenValidatingGeoLocationAndNationwide.cs
@@ -1,0 +1,104 @@
+﻿using System;
+using System.Collections.Generic;
+using Esfa.Vacancy.Application.Queries.SearchApprenticeshipVacancies;
+using Esfa.Vacancy.Domain.Validation;
+using FluentAssertions;
+using FluentValidation.Results;
+using NUnit.Framework;
+
+namespace Esfa.Vacancy.UnitTests.SearchApprenticeship.Application.GivenASearchApprenticeshipVacanciesRequestValidator
+{
+    [TestFixture]
+    public class WhenValidatingGeoLocationAndNationwide : GivenSearchApprenticeshipVacanciesRequestValidatorBase
+    {
+        private const string ErrorText = "When searching by geo-location 'Latitude', 'Longitude' and 'DistanceInMiles' are required. You have not provided '{0}'.";
+
+        private static List<TestCaseData> TestCases => new List<TestCaseData>
+        {
+            new TestCaseData(new SearchApprenticeshipVacanciesRequest
+                {
+                    Latitude = 52.399085,
+                    Longitude = -1.506115,
+                    DistanceInMiles = 23,
+                    NationwideOnly = true
+                }, new ValidationResult
+                {
+                    Errors = { new ValidationFailure("", ErrorMessages.SearchApprenticeships.GeoSearchAndNationwideNotAllowed)
+                    {
+                        ErrorCode = ErrorCodes.SearchApprenticeships.GeoSearchAndNationwideNotAllowed
+                    }}
+                })
+                .SetName("And combining geo-location with nationwide only then invalid"),
+            new TestCaseData(new SearchApprenticeshipVacanciesRequest
+                {
+                    Latitude = 52.399085,
+                    NationwideOnly = true
+                }, new ValidationResult
+                {
+                    Errors = { new ValidationFailure("", ErrorMessages.SearchApprenticeships.GeoSearchAndNationwideNotAllowed)
+                    {
+                        ErrorCode = ErrorCodes.SearchApprenticeships.GeoSearchAndNationwideNotAllowed
+                    }, new ValidationFailure("",  string.Format(ErrorText, nameof(SearchApprenticeshipVacanciesRequest.Longitude)))
+                    {
+                        ErrorCode = ErrorCodes.SearchApprenticeships.LongitudeMissingFromGeoSearch
+                    }, new ValidationFailure("",  string.Format(ErrorText, nameof(SearchApprenticeshipVacanciesRequest.DistanceInMiles)))
+                    {
+                        ErrorCode = ErrorCodes.SearchApprenticeships.DistanceMissingFromGeoSearch
+                    }}
+                })
+                .SetName("And combining latitude with nationwide only then invalid"),
+            new TestCaseData(new SearchApprenticeshipVacanciesRequest
+                {
+                    Longitude = 52.399085,
+                    NationwideOnly = true
+                }, new ValidationResult
+                {
+                    Errors = { new ValidationFailure("", ErrorMessages.SearchApprenticeships.GeoSearchAndNationwideNotAllowed)
+                    {
+                        ErrorCode = ErrorCodes.SearchApprenticeships.GeoSearchAndNationwideNotAllowed
+                    }, new ValidationFailure("",  string.Format(ErrorText, nameof(SearchApprenticeshipVacanciesRequest.Latitude)))
+                    {
+                        ErrorCode = ErrorCodes.SearchApprenticeships.LatitudeMissingFromGeoSearch
+                    }, new ValidationFailure("",  string.Format(ErrorText, nameof(SearchApprenticeshipVacanciesRequest.DistanceInMiles)))
+                    {
+                        ErrorCode = ErrorCodes.SearchApprenticeships.DistanceMissingFromGeoSearch
+                    }}
+                })
+                .SetName("And combining longitude with nationwide only then invalid"),
+            new TestCaseData(new SearchApprenticeshipVacanciesRequest
+                {
+                    DistanceInMiles = 525,
+                    NationwideOnly = true
+                }, new ValidationResult
+                {
+                    Errors = { new ValidationFailure("", ErrorMessages.SearchApprenticeships.GeoSearchAndNationwideNotAllowed)
+                    {
+                        ErrorCode = ErrorCodes.SearchApprenticeships.GeoSearchAndNationwideNotAllowed
+                    }, new ValidationFailure("",  string.Format(ErrorText, nameof(SearchApprenticeshipVacanciesRequest.Latitude)))
+                    {
+                        ErrorCode = ErrorCodes.SearchApprenticeships.LatitudeMissingFromGeoSearch
+                    }, new ValidationFailure("",  string.Format(ErrorText, nameof(SearchApprenticeshipVacanciesRequest.Longitude)))
+                    {
+                        ErrorCode = ErrorCodes.SearchApprenticeships.LongitudeMissingFromGeoSearch
+                    }}
+                })
+                .SetName("And combining distance with nationwide only then invalid")
+        };
+
+        [TestCaseSource(nameof(TestCases))]
+        public void AndRunningTestCases(SearchApprenticeshipVacanciesRequest request, ValidationResult expectedResult)
+        {
+            var actualResult = Validator.Validate(request);
+
+            foreach (var validationFailure in actualResult.Errors)
+            {
+                Console.WriteLine(validationFailure.ErrorMessage);
+            }
+
+            actualResult.IsValid.Should().Be(expectedResult.IsValid);
+            actualResult.Errors.ShouldAllBeEquivalentTo(expectedResult.Errors,
+                options => options.Including(failure => failure.ErrorMessage)
+                    .Including(failure => failure.ErrorCode));
+        }
+    }
+}

--- a/src/Esfa.Vacancy.UnitTests/SearchApprenticeship/Application/GivenASearchApprenticeshipVacanciesRequestValidator/WhenValidatingGeoSearchFields.cs
+++ b/src/Esfa.Vacancy.UnitTests/SearchApprenticeship/Application/GivenASearchApprenticeshipVacanciesRequestValidator/WhenValidatingGeoSearchFields.cs
@@ -17,7 +17,6 @@ namespace Esfa.Vacancy.UnitTests.SearchApprenticeship.Application.GivenASearchAp
         {
             new TestCaseData(new SearchApprenticeshipVacanciesRequest
                 {
-                    StandardLarsCodes = ValidStandardCodes,
                     Latitude = 52.399085,
                     Longitude = -1.506115,
                     DistanceInMiles = 235
@@ -25,7 +24,6 @@ namespace Esfa.Vacancy.UnitTests.SearchApprenticeship.Application.GivenASearchAp
                 .SetName("And all fields present then valid"),
             new TestCaseData(new SearchApprenticeshipVacanciesRequest
                 {
-                    StandardLarsCodes = ValidStandardCodes,
                     Latitude = 52.399085,
                     Longitude = -1.506115
                 }, new ValidationResult
@@ -38,7 +36,6 @@ namespace Esfa.Vacancy.UnitTests.SearchApprenticeship.Application.GivenASearchAp
                 .SetName("And no distance then invalid"),
             new TestCaseData(new SearchApprenticeshipVacanciesRequest
                 {
-                    StandardLarsCodes = ValidStandardCodes,
                     Longitude = -1.506115,
                     DistanceInMiles = 342
                 }, new ValidationResult
@@ -51,7 +48,6 @@ namespace Esfa.Vacancy.UnitTests.SearchApprenticeship.Application.GivenASearchAp
                 .SetName("And no latitude then invalid"),
             new TestCaseData(new SearchApprenticeshipVacanciesRequest
                 {
-                    StandardLarsCodes = ValidStandardCodes,
                     Latitude = 52.399085,
                     DistanceInMiles = 342
                 }, new ValidationResult
@@ -64,7 +60,6 @@ namespace Esfa.Vacancy.UnitTests.SearchApprenticeship.Application.GivenASearchAp
                 .SetName("And no longitude then invalid"),
             new TestCaseData(new SearchApprenticeshipVacanciesRequest
                 {
-                    StandardLarsCodes = ValidStandardCodes,
                     Latitude = 52.399085
                 }, new ValidationResult
                 {
@@ -79,7 +74,6 @@ namespace Esfa.Vacancy.UnitTests.SearchApprenticeship.Application.GivenASearchAp
                 .SetName("And only latitude then invalid"),
             new TestCaseData(new SearchApprenticeshipVacanciesRequest
                 {
-                    StandardLarsCodes = ValidStandardCodes,
                     Longitude = -1.506115
                 }, new ValidationResult
                 {
@@ -94,7 +88,6 @@ namespace Esfa.Vacancy.UnitTests.SearchApprenticeship.Application.GivenASearchAp
                 .SetName("And only longitude then invalid"),
             new TestCaseData(new SearchApprenticeshipVacanciesRequest
                 {
-                    StandardLarsCodes = ValidStandardCodes,
                     DistanceInMiles = 342
                 }, new ValidationResult
                 {

--- a/src/Esfa.Vacancy.UnitTests/SearchApprenticeship/Application/GivenASearchApprenticeshipVacanciesRequestValidator/WhenValidatingLatitude.cs
+++ b/src/Esfa.Vacancy.UnitTests/SearchApprenticeship/Application/GivenASearchApprenticeshipVacanciesRequestValidator/WhenValidatingLatitude.cs
@@ -15,7 +15,6 @@ namespace Esfa.Vacancy.UnitTests.SearchApprenticeship.Application.GivenASearchAp
         {
             new TestCaseData(new SearchApprenticeshipVacanciesRequest
                 {
-                    StandardLarsCodes = ValidStandardCodes,
                     Latitude = 52.399085,
                     Longitude = -1.506115,
                     DistanceInMiles = 235
@@ -23,7 +22,6 @@ namespace Esfa.Vacancy.UnitTests.SearchApprenticeship.Application.GivenASearchAp
                 .SetName("And between -90 and 90 then valid"),
             new TestCaseData(new SearchApprenticeshipVacanciesRequest
                 {
-                    StandardLarsCodes = ValidStandardCodes,
                     Latitude = -90,
                     Longitude = -1.506115,
                     DistanceInMiles = 235
@@ -31,7 +29,6 @@ namespace Esfa.Vacancy.UnitTests.SearchApprenticeship.Application.GivenASearchAp
                 .SetName("And -90 then valid"),
             new TestCaseData(new SearchApprenticeshipVacanciesRequest
                 {
-                    StandardLarsCodes = ValidStandardCodes,
                     Latitude = 90,
                     Longitude = -1.506115,
                     DistanceInMiles = 235
@@ -39,7 +36,6 @@ namespace Esfa.Vacancy.UnitTests.SearchApprenticeship.Application.GivenASearchAp
                 .SetName("And 90 then valid"),
             new TestCaseData(new SearchApprenticeshipVacanciesRequest
                 {
-                    StandardLarsCodes = ValidStandardCodes,
                     Latitude = -90.1,
                     Longitude = -1.506115,
                     DistanceInMiles = 235
@@ -53,7 +49,6 @@ namespace Esfa.Vacancy.UnitTests.SearchApprenticeship.Application.GivenASearchAp
                 .SetName("And less than -90 then invalid"),
             new TestCaseData(new SearchApprenticeshipVacanciesRequest
                 {
-                    StandardLarsCodes = ValidStandardCodes,
                     Latitude = 90.1,
                     Longitude = -1.506115,
                     DistanceInMiles = 235

--- a/src/Esfa.Vacancy.UnitTests/SearchApprenticeship/Application/GivenASearchApprenticeshipVacanciesRequestValidator/WhenValidatingLongitude.cs
+++ b/src/Esfa.Vacancy.UnitTests/SearchApprenticeship/Application/GivenASearchApprenticeshipVacanciesRequestValidator/WhenValidatingLongitude.cs
@@ -15,7 +15,6 @@ namespace Esfa.Vacancy.UnitTests.SearchApprenticeship.Application.GivenASearchAp
         {
             new TestCaseData(new SearchApprenticeshipVacanciesRequest
                 {
-                    StandardLarsCodes = ValidStandardCodes,
                     Latitude = 52.399085,
                     Longitude = -1.506115,
                     DistanceInMiles = 235
@@ -23,7 +22,6 @@ namespace Esfa.Vacancy.UnitTests.SearchApprenticeship.Application.GivenASearchAp
                 .SetName("And between -180 and 180 then valid"),
             new TestCaseData(new SearchApprenticeshipVacanciesRequest
                 {
-                    StandardLarsCodes = ValidStandardCodes,
                     Latitude = 45,
                     Longitude = -180,
                     DistanceInMiles = 235
@@ -31,7 +29,6 @@ namespace Esfa.Vacancy.UnitTests.SearchApprenticeship.Application.GivenASearchAp
                 .SetName("And -180 then valid"),
             new TestCaseData(new SearchApprenticeshipVacanciesRequest
                 {
-                    StandardLarsCodes = ValidStandardCodes,
                     Latitude = 45,
                     Longitude = 180,
                     DistanceInMiles = 235
@@ -39,7 +36,6 @@ namespace Esfa.Vacancy.UnitTests.SearchApprenticeship.Application.GivenASearchAp
                 .SetName("And 180 then valid"),
             new TestCaseData(new SearchApprenticeshipVacanciesRequest
                 {
-                    StandardLarsCodes = ValidStandardCodes,
                     Latitude = 45,
                     Longitude = -180.1,
                     DistanceInMiles = 235
@@ -53,7 +49,6 @@ namespace Esfa.Vacancy.UnitTests.SearchApprenticeship.Application.GivenASearchAp
                 .SetName("And less than -180 then invalid"),
             new TestCaseData(new SearchApprenticeshipVacanciesRequest
                 {
-                    StandardLarsCodes = ValidStandardCodes,
                     Latitude = 45,
                     Longitude = 180.1,
                     DistanceInMiles = 235

--- a/src/Esfa.Vacancy.UnitTests/SearchApprenticeship/Application/GivenASearchApprenticeshipVacanciesRequestValidator/WhenValidatingMinimumRequiredFields.cs
+++ b/src/Esfa.Vacancy.UnitTests/SearchApprenticeship/Application/GivenASearchApprenticeshipVacanciesRequestValidator/WhenValidatingMinimumRequiredFields.cs
@@ -75,9 +75,9 @@ namespace Esfa.Vacancy.UnitTests.SearchApprenticeship.Application.GivenASearchAp
                 {
                     Errors =
                     {
-                        new ValidationFailure("", ErrorMessages.SearchApprenticeships.StandardAndFrameworkCodeNotProvided)
+                        new ValidationFailure("", ErrorMessages.SearchApprenticeships.MinimumRequiredFieldsNotProvided)
                         {
-                            ErrorCode = ErrorCodes.SearchApprenticeships.StandardAndFrameworkCodeNotProvided
+                            ErrorCode = ErrorCodes.SearchApprenticeships.MinimumRequiredFieldsNotProvided
                         }
                     }
                 })

--- a/src/Esfa.Vacancy.UnitTests/SearchApprenticeship/Application/GivenASearchApprenticeshipVacanciesRequestValidator/WhenValidatingMinimumRequiredFields.cs
+++ b/src/Esfa.Vacancy.UnitTests/SearchApprenticeship/Application/GivenASearchApprenticeshipVacanciesRequestValidator/WhenValidatingMinimumRequiredFields.cs
@@ -54,6 +54,16 @@ namespace Esfa.Vacancy.UnitTests.SearchApprenticeship.Application.GivenASearchAp
                     StandardLarsCodes = ValidStandardCodes
                 }, new ValidationResult())
                 .SetName("Frameworks and Standards present is allowed"),
+            new TestCaseData(new SearchApprenticeshipVacanciesRequest
+                {
+                    NationwideOnly = true
+                }, new ValidationResult())
+                .SetName("Nationwide present is allowed"),
+            new TestCaseData(new SearchApprenticeshipVacanciesRequest
+                {
+                    PostedInLastNumberOfDays = 3242
+                }, new ValidationResult())
+                .SetName("PostedInLastNumberOfDays present is allowed"),
             new TestCaseData(new SearchApprenticeshipVacanciesRequest(), new ValidationResult
                 {
                     Errors =
@@ -64,7 +74,7 @@ namespace Esfa.Vacancy.UnitTests.SearchApprenticeship.Application.GivenASearchAp
                         }
                     }
                 })
-                .SetName("No Frameworks or Standards present is not allowed")
+                .SetName("No required fields present is not allowed")
         };
     }
 }

--- a/src/Esfa.Vacancy.UnitTests/SearchApprenticeship/Application/GivenASearchApprenticeshipVacanciesRequestValidator/WhenValidatingMinimumRequiredFields.cs
+++ b/src/Esfa.Vacancy.UnitTests/SearchApprenticeship/Application/GivenASearchApprenticeshipVacanciesRequestValidator/WhenValidatingMinimumRequiredFields.cs
@@ -64,6 +64,13 @@ namespace Esfa.Vacancy.UnitTests.SearchApprenticeship.Application.GivenASearchAp
                     PostedInLastNumberOfDays = 3242
                 }, new ValidationResult())
                 .SetName("PostedInLastNumberOfDays present is allowed"),
+            new TestCaseData(new SearchApprenticeshipVacanciesRequest
+                {
+                    Latitude = 23.2,
+                    Longitude = 75.7,
+                    DistanceInMiles = 76
+                }, new ValidationResult())
+                .SetName("Geo-Location fields present is allowed"),
             new TestCaseData(new SearchApprenticeshipVacanciesRequest(), new ValidationResult
                 {
                     Errors =

--- a/src/Esfa.Vacancy.UnitTests/SearchApprenticeship/Application/GivenASearchApprenticeshipVacanciesRequestValidator/WhenValidatingMinimumRequiredFields.cs
+++ b/src/Esfa.Vacancy.UnitTests/SearchApprenticeship/Application/GivenASearchApprenticeshipVacanciesRequestValidator/WhenValidatingMinimumRequiredFields.cs
@@ -81,7 +81,22 @@ namespace Esfa.Vacancy.UnitTests.SearchApprenticeship.Application.GivenASearchAp
                         }
                     }
                 })
-                .SetName("No required fields present is not allowed")
+                .SetName("No required fields present is not allowed"),
+            new TestCaseData(new SearchApprenticeshipVacanciesRequest
+                {
+                    PageNumber = 3
+                }, 
+                new ValidationResult
+                {
+                    Errors =
+                    {
+                        new ValidationFailure("", ErrorMessages.SearchApprenticeships.MinimumRequiredFieldsNotProvided)
+                        {
+                            ErrorCode = ErrorCodes.SearchApprenticeships.MinimumRequiredFieldsNotProvided
+                        }
+                    }
+                })
+                .SetName("Non required field only present is not allowed")
         };
     }
 }

--- a/src/Esfa.Vacancy.UnitTests/SearchApprenticeship/Application/GivenASearchApprenticeshipVacanciesRequestValidator/WhenValidatingPageNumber.cs
+++ b/src/Esfa.Vacancy.UnitTests/SearchApprenticeship/Application/GivenASearchApprenticeshipVacanciesRequestValidator/WhenValidatingPageNumber.cs
@@ -40,12 +40,12 @@ namespace Esfa.Vacancy.UnitTests.SearchApprenticeship.Application.GivenASearchAp
         {
             new TestCaseData(new SearchApprenticeshipVacanciesRequest
                 {
-                    StandardLarsCodes = ValidStandardCodes
+                    NationwideOnly = true,
                 }, new ValidationResult())
                 .SetName("Then default is valid"),
             new TestCaseData(new SearchApprenticeshipVacanciesRequest
                 {
-                    StandardLarsCodes = ValidStandardCodes,
+                    NationwideOnly = true,
                     PageNumber = 0
                 }, new ValidationResult
                 {
@@ -57,7 +57,7 @@ namespace Esfa.Vacancy.UnitTests.SearchApprenticeship.Application.GivenASearchAp
                 .SetName("Then less than 1 is invalid"),
             new TestCaseData(new SearchApprenticeshipVacanciesRequest
                 {
-                    StandardLarsCodes = ValidStandardCodes,
+                    NationwideOnly = true,
                     PageNumber = new Random().Next()
                 }, new ValidationResult())
                 .SetName("Then greater than 1 is valid")

--- a/src/Esfa.Vacancy.UnitTests/SearchApprenticeship/Application/GivenASearchApprenticeshipVacanciesRequestValidator/WhenValidatingPageSize.cs
+++ b/src/Esfa.Vacancy.UnitTests/SearchApprenticeship/Application/GivenASearchApprenticeshipVacanciesRequestValidator/WhenValidatingPageSize.cs
@@ -41,12 +41,12 @@ namespace Esfa.Vacancy.UnitTests.SearchApprenticeship.Application.GivenASearchAp
         {
             new TestCaseData(new SearchApprenticeshipVacanciesRequest
                 {
-                    StandardLarsCodes = ValidStandardCodes
+                    NationwideOnly = true,
                 }, new ValidationResult())
                 .SetName("Then default is valid"),
             new TestCaseData(new SearchApprenticeshipVacanciesRequest
                 {
-                    StandardLarsCodes = ValidStandardCodes,
+                    NationwideOnly = true,
                     PageSize = 0
                 }, new ValidationResult
                 {
@@ -58,25 +58,25 @@ namespace Esfa.Vacancy.UnitTests.SearchApprenticeship.Application.GivenASearchAp
                 .SetName("Then less than 1 is invalid"),
             new TestCaseData(new SearchApprenticeshipVacanciesRequest
                 {
-                    StandardLarsCodes = ValidStandardCodes,
+                    NationwideOnly = true,
                     PageSize = 1
                 }, new ValidationResult())
                 .SetName("Then 1 is valid"),
             new TestCaseData(new SearchApprenticeshipVacanciesRequest
                 {
-                    StandardLarsCodes = ValidStandardCodes,
+                    NationwideOnly = true,
                     PageSize = new Random().Next(1, 250)
                 }, new ValidationResult())
                 .SetName("Then between 1 and 250 is valid"),
             new TestCaseData(new SearchApprenticeshipVacanciesRequest
                 {
-                    StandardLarsCodes = ValidStandardCodes,
+                    NationwideOnly = true,
                     PageSize = 250
                 }, new ValidationResult())
                 .SetName("Then 250 is valid"),
             new TestCaseData(new SearchApprenticeshipVacanciesRequest
                 {
-                    StandardLarsCodes = ValidStandardCodes,
+                    NationwideOnly = true,
                     PageSize = 251
                 }, new ValidationResult
                 {

--- a/src/Esfa.Vacancy.UnitTests/SearchApprenticeship/Application/GivenASearchApprenticeshipVacanciesRequestValidator/WhenValidatingPostedInDays.cs
+++ b/src/Esfa.Vacancy.UnitTests/SearchApprenticeship/Application/GivenASearchApprenticeshipVacanciesRequestValidator/WhenValidatingPostedInDays.cs
@@ -41,12 +41,11 @@ namespace Esfa.Vacancy.UnitTests.SearchApprenticeship.Application.GivenASearchAp
         {
             new TestCaseData(new SearchApprenticeshipVacanciesRequest
                 {
-                    StandardLarsCodes = ValidStandardCodes
+                    NationwideOnly = true,
                 }, new ValidationResult())
                 .SetName("Then default is valid"),
             new TestCaseData(new SearchApprenticeshipVacanciesRequest
                 {
-                    StandardLarsCodes = ValidStandardCodes,
                     PostedInLastNumberOfDays = -1
                 }, new ValidationResult
                 {
@@ -58,13 +57,11 @@ namespace Esfa.Vacancy.UnitTests.SearchApprenticeship.Application.GivenASearchAp
                 .SetName("Then less than 0 is invalid"),
             new TestCaseData(new SearchApprenticeshipVacanciesRequest
                 {
-                    StandardLarsCodes = ValidStandardCodes,
                     PostedInLastNumberOfDays = 0
                 }, new ValidationResult())
                 .SetName("Then 0 is valid"),
             new TestCaseData(new SearchApprenticeshipVacanciesRequest
                 {
-                    StandardLarsCodes = ValidStandardCodes,
                     PostedInLastNumberOfDays = new Random().Next()
                 }, new ValidationResult())
                 .SetName("Then greater than 0 is valid")

--- a/src/Esfa.Vacancy.UnitTests/SearchApprenticeship/Application/GivenASearchApprenticeshipVacanciesRequestValidator/WhenValidatingStandardCodes.cs
+++ b/src/Esfa.Vacancy.UnitTests/SearchApprenticeship/Application/GivenASearchApprenticeshipVacanciesRequestValidator/WhenValidatingStandardCodes.cs
@@ -11,8 +11,7 @@ namespace Esfa.Vacancy.UnitTests.SearchApprenticeship.Application.GivenASearchAp
     [TestFixture]
     public class WhenValidatingStandardCodes : GivenSearchApprenticeshipVacanciesRequestValidatorBase
     {
-
-        public static List<TestCaseData> SuccessTestCases => new List<TestCaseData>
+        private static List<TestCaseData> SuccessTestCases => new List<TestCaseData>
         {
             new TestCaseData(ValidStandardCodes)
                 .SetName("Then any number is valid"),
@@ -34,7 +33,7 @@ namespace Esfa.Vacancy.UnitTests.SearchApprenticeship.Application.GivenASearchAp
             result.IsValid.Should().BeTrue();
         }
 
-        public static List<TestCaseData> FailingTestCases => new List<TestCaseData>
+        private static List<TestCaseData> FailingTestCases => new List<TestCaseData>
         {
             new TestCaseData("e",
                 ErrorMessages.SearchApprenticeships.GetTrainingCodeShouldBeNumberErrorMessage(TrainingType.Standard, "e"),


### PR DESCRIPTION
Adds new validation rules to search endpoint:

- you can now search by either training type (existing) or age or location or nationwide only.
- you cannot search by location and nationwide only