### PR TITLE
RA-1423 Adding shared assembly info file

### DIFF
--- a/src/Esfa.Vacancy.Api.Core/Esfa.Vacancy.Api.Core.csproj
+++ b/src/Esfa.Vacancy.Api.Core/Esfa.Vacancy.Api.Core.csproj
@@ -61,6 +61,9 @@
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="..\SharedAssemblyInfo.cs">
+      <Link>Properties\SharedAssemblyInfo.cs</Link>
+    </Compile>
     <Compile Include="CustomErrorResult.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="RequestContext.cs" />

--- a/src/Esfa.Vacancy.Api.Core/Properties/AssemblyInfo.cs
+++ b/src/Esfa.Vacancy.Api.Core/Properties/AssemblyInfo.cs
@@ -5,13 +5,6 @@ using System.Runtime.InteropServices;
 // set of attributes. Change these attribute values to modify the information
 // associated with an assembly.
 [assembly: AssemblyTitle("Esfa.Vacancy.Api.Core")]
-[assembly: AssemblyDescription("")]
-[assembly: AssemblyConfiguration("")]
-[assembly: AssemblyCompany("")]
-[assembly: AssemblyProduct("Esfa.Vacancy.Api.Core")]
-[assembly: AssemblyCopyright("Copyright © 2018")]
-[assembly: AssemblyTrademark("")]
-[assembly: AssemblyCulture("")]
 
 // Setting ComVisible to false makes the types in this assembly not visible
 // to COM components.  If you need to access a type in this assembly from

--- a/src/Esfa.Vacancy.Api.Types/Esfa.Vacancy.Api.Types.csproj
+++ b/src/Esfa.Vacancy.Api.Types/Esfa.Vacancy.Api.Types.csproj
@@ -41,6 +41,9 @@
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="..\SharedAssemblyInfo.cs">
+      <Link>Properties\SharedAssemblyInfo.cs</Link>
+    </Compile>
     <Compile Include="Address.cs" />
     <Compile Include="GeoCodedAddress.cs" />
     <Compile Include="BadRequestError.cs" />

--- a/src/Esfa.Vacancy.Api.Types/Properties/AssemblyInfo.cs
+++ b/src/Esfa.Vacancy.Api.Types/Properties/AssemblyInfo.cs
@@ -5,13 +5,6 @@ using System.Runtime.InteropServices;
 // set of attributes. Change these attribute values to modify the information
 // associated with an assembly.
 [assembly: AssemblyTitle("Esfa.Vacancy.Api.Types")]
-[assembly: AssemblyDescription("")]
-[assembly: AssemblyConfiguration("")]
-[assembly: AssemblyCompany("")]
-[assembly: AssemblyProduct("Esfa.Vacancy.Api.Types")]
-[assembly: AssemblyCopyright("Copyright © 2018")]
-[assembly: AssemblyTrademark("")]
-[assembly: AssemblyCulture("")]
 
 // Setting ComVisible to false makes the types in this assembly not visible 
 // to COM components.  If you need to access a type in this assembly from 

--- a/src/Esfa.Vacancy.Api.sln
+++ b/src/Esfa.Vacancy.Api.sln
@@ -6,6 +6,9 @@ MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Esfa.Vacancy.Infrastructure", "Esfa.Vacancy.Infrastructure\Esfa.Vacancy.Infrastructure.csproj", "{3AAE3727-FB7E-4F2A-854C-E95BAC1FAE1A}"
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{A5CF3CE7-7446-441B-A5AE-72AD4CF2E98C}"
+	ProjectSection(SolutionItems) = preProject
+		SharedAssemblyInfo.cs = SharedAssemblyInfo.cs
+	EndProjectSection
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Esfa.Vacancy.UnitTests", "Esfa.Vacancy.UnitTests\Esfa.Vacancy.UnitTests.csproj", "{56AA0C40-2D0A-43C7-A3CE-5E4B3AC101A2}"
 EndProject

--- a/src/Esfa.Vacancy.Application/Esfa.Vacancy.Application.csproj
+++ b/src/Esfa.Vacancy.Application/Esfa.Vacancy.Application.csproj
@@ -64,6 +64,9 @@
     </Reference>
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="..\SharedAssemblyInfo.cs">
+      <Link>Properties\SharedAssemblyInfo.cs</Link>
+    </Compile>
     <Compile Include="Commands\CreateApprenticeship\CreateApprenticeshipCommandHandler.cs" />
     <Compile Include="Commands\CreateApprenticeship\CreateApprenticeshipParametersMapper.cs" />
     <Compile Include="Commands\CreateApprenticeship\CreateApprenticeshipRequest.cs" />

--- a/src/Esfa.Vacancy.Application/Properties/AssemblyInfo.cs
+++ b/src/Esfa.Vacancy.Application/Properties/AssemblyInfo.cs
@@ -5,13 +5,6 @@ using System.Runtime.InteropServices;
 // set of attributes. Change these attribute values to modify the information
 // associated with an assembly.
 [assembly: AssemblyTitle("Esfa.Vacancy.Application")]
-[assembly: AssemblyDescription("")]
-[assembly: AssemblyConfiguration("")]
-[assembly: AssemblyCompany("")]
-[assembly: AssemblyProduct("Esfa.Vacancy.Application")]
-[assembly: AssemblyCopyright("Copyright @ 2018")]
-[assembly: AssemblyTrademark("")]
-[assembly: AssemblyCulture("")]
 
 // Setting ComVisible to false makes the types in this assembly not visible 
 // to COM components.  If you need to access a type in this assembly from 

--- a/src/Esfa.Vacancy.Domain/Esfa.Vacancy.Domain.csproj
+++ b/src/Esfa.Vacancy.Domain/Esfa.Vacancy.Domain.csproj
@@ -35,6 +35,9 @@
     <Reference Include="System.Core" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="..\SharedAssemblyInfo.cs">
+      <Link>Properties\SharedAssemblyInfo.cs</Link>
+    </Compile>
     <Compile Include="Entities\Address.cs" />
     <Compile Include="Entities\ApprenticeshipSummary.cs" />
     <Compile Include="Entities\CreateApprenticeshipParameters.cs" />

--- a/src/Esfa.Vacancy.Domain/Properties/AssemblyInfo.cs
+++ b/src/Esfa.Vacancy.Domain/Properties/AssemblyInfo.cs
@@ -5,13 +5,6 @@ using System.Runtime.InteropServices;
 // set of attributes. Change these attribute values to modify the information
 // associated with an assembly.
 [assembly: AssemblyTitle("Esfa.Vacancy.Domain")]
-[assembly: AssemblyDescription("")]
-[assembly: AssemblyConfiguration("")]
-[assembly: AssemblyCompany("")]
-[assembly: AssemblyProduct("Esfa.Vacancy.Domain")]
-[assembly: AssemblyCopyright("Copyright © 2018")]
-[assembly: AssemblyTrademark("")]
-[assembly: AssemblyCulture("")]
 
 // Setting ComVisible to false makes the types in this assembly not visible 
 // to COM components.  If you need to access a type in this assembly from 

--- a/src/Esfa.Vacancy.Infrastructure/Esfa.Vacancy.Infrastructure.csproj
+++ b/src/Esfa.Vacancy.Infrastructure/Esfa.Vacancy.Infrastructure.csproj
@@ -110,6 +110,9 @@
     <Reference Include="System.Xml.Linq" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="..\SharedAssemblyInfo.cs">
+      <Link>Properties\SharedAssemblyInfo.cs</Link>
+    </Compile>
     <Compile Include="Caching\AzureRedisCacheService.cs" />
     <Compile Include="Exceptions\InfrastructureException.cs" />
     <Compile Include="Factories\ElasticClientFactory.cs" />

--- a/src/Esfa.Vacancy.Infrastructure/Properties/AssemblyInfo.cs
+++ b/src/Esfa.Vacancy.Infrastructure/Properties/AssemblyInfo.cs
@@ -5,13 +5,6 @@ using System.Runtime.InteropServices;
 // set of attributes. Change these attribute values to modify the information
 // associated with an assembly.
 [assembly: AssemblyTitle("Esfa.Vacancy.Infrastructure")]
-[assembly: AssemblyDescription("")]
-[assembly: AssemblyConfiguration("")]
-[assembly: AssemblyCompany("")]
-[assembly: AssemblyProduct("Esfa.Vacancy.Infrastructure")]
-[assembly: AssemblyCopyright("Copyright © 2018")]
-[assembly: AssemblyTrademark("")]
-[assembly: AssemblyCulture("")]
 
 // Setting ComVisible to false makes the types in this assembly not visible 
 // to COM components.  If you need to access a type in this assembly from 

--- a/src/Esfa.Vacancy.Manage.Api/Esfa.Vacancy.Manage.Api.csproj
+++ b/src/Esfa.Vacancy.Manage.Api/Esfa.Vacancy.Manage.Api.csproj
@@ -195,6 +195,9 @@
     </Reference>
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="..\SharedAssemblyInfo.cs">
+      <Link>Properties\SharedAssemblyInfo.cs</Link>
+    </Compile>
     <Compile Include="App_Start\ApiFilterConfig.cs" />
     <Compile Include="App_Start\RouteConfig.cs" />
     <Compile Include="App_Start\StructuremapConfig.cs" />

--- a/src/Esfa.Vacancy.Manage.Api/Properties/AssemblyInfo.cs
+++ b/src/Esfa.Vacancy.Manage.Api/Properties/AssemblyInfo.cs
@@ -1,18 +1,10 @@
 ﻿using System.Reflection;
-using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 
 // General Information about an assembly is controlled through the following
 // set of attributes. Change these attribute values to modify the information
 // associated with an assembly.
 [assembly: AssemblyTitle("Esfa.Vacancy.Manage.Api")]
-[assembly: AssemblyDescription("")]
-[assembly: AssemblyConfiguration("")]
-[assembly: AssemblyCompany("")]
-[assembly: AssemblyProduct("Esfa.Vacancy.Manage.Api")]
-[assembly: AssemblyCopyright("Copyright © 2018")]
-[assembly: AssemblyTrademark("")]
-[assembly: AssemblyCulture("")]
 
 // Setting ComVisible to false makes the types in this assembly not visible
 // to COM components.  If you need to access a type in this assembly from

--- a/src/Esfa.Vacancy.Register.Api/Esfa.Vacancy.Register.Api.csproj
+++ b/src/Esfa.Vacancy.Register.Api/Esfa.Vacancy.Register.Api.csproj
@@ -284,6 +284,9 @@
     </Content>
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="..\SharedAssemblyInfo.cs">
+      <Link>Properties\SharedAssemblyInfo.cs</Link>
+    </Compile>
     <Compile Include="App_Start\AutoMapperConfig.cs" />
     <Compile Include="App_Start\ApiFilterConfig.cs" />
     <Compile Include="Constants\RouteName.cs" />

--- a/src/Esfa.Vacancy.Register.Api/Properties/AssemblyInfo.cs
+++ b/src/Esfa.Vacancy.Register.Api/Properties/AssemblyInfo.cs
@@ -6,13 +6,6 @@ using System.Runtime.InteropServices;
 // set of attributes. Change these attribute values to modify the information
 // associated with an assembly.
 [assembly: AssemblyTitle("Esfa.Vacancy.Register.Api")]
-[assembly: AssemblyDescription("")]
-[assembly: AssemblyConfiguration("")]
-[assembly: AssemblyCompany("")]
-[assembly: AssemblyProduct("Esfa.Vacancy.Register.Api")]
-[assembly: AssemblyCopyright("Copyright © 2018")]
-[assembly: AssemblyTrademark("")]
-[assembly: AssemblyCulture("")]
 
 // Setting ComVisible to false makes the types in this assembly not visible 
 // to COM components.  If you need to access a type in this assembly from 

--- a/src/Esfa.Vacancy.UnitTests/Esfa.Vacancy.UnitTests.csproj
+++ b/src/Esfa.Vacancy.UnitTests/Esfa.Vacancy.UnitTests.csproj
@@ -112,6 +112,9 @@
     <Reference Include="System.Xml.Linq" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="..\SharedAssemblyInfo.cs">
+      <Link>Properties\SharedAssemblyInfo.cs</Link>
+    </Compile>
     <Compile Include="CreateApprenticeship\Api\Mappings\GivenACreateApprenticeshipRequestMapper\WhenMappingFromApiParameters.cs" />
     <Compile Include="CreateApprenticeship\Api\Mappings\GivenACreateApprenticeshipResponseMapper\WhenMappingVacancyReferenceNumber.cs" />
     <Compile Include="CreateApprenticeship\Api\Orchestrators\GivenACreateApprenticeshipOrchestrator\WhenCreatingAnApprenticeshipVacancy.cs" />

--- a/src/Esfa.Vacancy.UnitTests/Properties/AssemblyInfo.cs
+++ b/src/Esfa.Vacancy.UnitTests/Properties/AssemblyInfo.cs
@@ -5,13 +5,6 @@ using System.Runtime.InteropServices;
 // set of attributes. Change these attribute values to modify the information
 // associated with an assembly.
 [assembly: AssemblyTitle("Esfa.Vacancy.UnitTests")]
-[assembly: AssemblyDescription("")]
-[assembly: AssemblyConfiguration("")]
-[assembly: AssemblyCompany("")]
-[assembly: AssemblyProduct("Esfa.Vacancy.UnitTests")]
-[assembly: AssemblyCopyright("Copyright © 2018")]
-[assembly: AssemblyTrademark("")]
-[assembly: AssemblyCulture("")]
 
 // Setting ComVisible to false makes the types in this assembly not visible 
 // to COM components.  If you need to access a type in this assembly from 

--- a/src/SharedAssemblyInfo.cs
+++ b/src/SharedAssemblyInfo.cs
@@ -1,0 +1,11 @@
+﻿using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+// General Information about an assembly is controlled through the following 
+// set of attributes. Change these attribute values to modify the information
+// associated with an assembly.
+[assembly: AssemblyCompany("Education & Skills Funding Agency")]
+[assembly: AssemblyProduct("Esfa Vacancy API")]
+[assembly: AssemblyCopyright("Copyright ©")]
+[assembly: AssemblyCulture("en-GB")]


### PR DESCRIPTION
I was thinking of renaming the `AssemblyInfo.cs` to `BlahAssemblyInfo.cs` in each of the projects so there would be one new `AssemblyInfo.cs` that is shared via linked file to the projects and sits inside the solution. This was so the GitVersion task only find and places the attribute in one `AssemblyInfo.cs` file instead of 8. But then I thought that would have been more confusing and settled on this approach.