### PR TITLE
RA-1530 Allow whitespaces in the postcode regex 

### DIFF
--- a/src/Esfa.Vacancy.Application/Commands/CreateApprenticeship/Validators/Extensions.cs
+++ b/src/Esfa.Vacancy.Application/Commands/CreateApprenticeship/Validators/Extensions.cs
@@ -12,7 +12,7 @@ namespace Esfa.Vacancy.Application.Commands.CreateApprenticeship.Validators
         private const string RegexInputsBlacklist = @"<\s*i\s*n\s*p\s*u\s*t\s*[^>]*\s*[^>]*\s*[^>]*>";
         private const string RegexObjectsBlacklist = @"<\s*o\s*b\s*j\s*e\s*c\s*t\s*[^>]*\s*[^>]*\s*[^>]*>";
         // See http://stackoverflow.com/questions/164979/uk-postcode-regex-comprehensive
-        private const string RegexPostcode = "^(([gG][iI][rR] {0,}0[aA]{2})|((([a-pr-uwyzA-PR-UWYZ][a-hk-yA-HK-Y]?[0-9][0-9]?)|(([a-pr-uwyzA-PR-UWYZ][0-9][a-hjkstuwA-HJKSTUW])|([a-pr-uwyzA-PR-UWYZ][a-hk-yA-HK-Y][0-9][abehmnprv-yABEHMNPRV-Y]))) {0,}[0-9][abd-hjlnp-uw-zABD-HJLNP-UW-Z]{2}))$";
+        private const string RegexPostcode = @"^(\s|([gG][iI][rR] {0,}0[aA]{2})|((([a-pr-uwyzA-PR-UWYZ][a-hk-yA-HK-Y]?[0-9][0-9]?)|(([a-pr-uwyzA-PR-UWYZ][0-9][a-hjkstuwA-HJKSTUW])|([a-pr-uwyzA-PR-UWYZ][a-hk-yA-HK-Y][0-9][abehmnprv-yABEHMNPRV-Y]))) {0,}[0-9][abd-hjlnp-uw-zABD-HJLNP-UW-Z]{2}))*$";
 
         public static IRuleBuilderOptions<T, string> MustBeAValidPostcode<T>(
             this IRuleBuilder<T, string> rule)

--- a/src/Esfa.Vacancy.Domain/Validation/ErrorMessages.cs
+++ b/src/Esfa.Vacancy.Domain/Validation/ErrorMessages.cs
@@ -38,9 +38,9 @@ namespace Esfa.Vacancy.Domain.Validation
         {
             public const string WhitelistFailed = "'{PropertyName}' can't contain invalid characters";
             public const string HtmlBlacklistFailed = "'{PropertyName}' can't contain blacklisted HTML elements";
-            public const string PostcodeInvalid = "'{PropertyName}' is invalid";
+            public const string PostcodeInvalid = "'{PropertyName}' is invalid.";
             public const string TitleShouldIncludeWordApprentice = "'Title' must contain the word 'apprentice' or 'apprenticeship'.";
-            
+
             public const string ApplicationClosingDateBeforeTomorrow = "'Application Closing Date' must be after today's date.";
             public const string ExpectedStartDateBeforeClosingDate = "'Expected Start Date' must be after the specified application closing date.";
             public const string CreateApprenticeshipParametersIsNull = "Either no request was provided or the request could not be recognised.";

--- a/src/Esfa.Vacancy.UnitTests/CreateApprenticeship/Application/GivenACreateApprenticeshipRequestValidator/AndLocationTypeOfOther/WhenValidatingPostcode.cs
+++ b/src/Esfa.Vacancy.UnitTests/CreateApprenticeship/Application/GivenACreateApprenticeshipRequestValidator/AndLocationTypeOfOther/WhenValidatingPostcode.cs
@@ -1,6 +1,8 @@
 ﻿using System.Collections.Generic;
+using System.Linq;
 using Esfa.Vacancy.Application.Commands.CreateApprenticeship;
 using Esfa.Vacancy.Application.Commands.CreateApprenticeship.Validators;
+using FluentAssertions;
 using FluentValidation.TestHelper;
 using NUnit.Framework;
 
@@ -8,17 +10,25 @@ namespace Esfa.Vacancy.UnitTests.CreateApprenticeship.Application.GivenACreateAp
 {
     public class WhenValidatingPostcode
     {
+        private const string EmptyMessage = "'Postcode' should not be empty.";
+        private const string InvalidMessage = "'Postcode' is invalid.";
         private static List<TestCaseData> TestCases() =>
             new List<TestCaseData>
             {
-                new TestCaseData(LocationType.OtherLocation, false, null, "31048").SetName("And is null Then is invalid"),
-                new TestCaseData(LocationType.OtherLocation, false, new string('a', 10),  "31049").SetName("And exceeds 9 characters Then is invalid"),
-                new TestCaseData(LocationType.OtherLocation, false, "<p>", "31049").SetName("And contains illegal chars Then is invalid"),
-                new TestCaseData(LocationType.OtherLocation, true, "CV1 2WT", null).SetName("And is in allowed format Then is valid"),
+                new TestCaseData(LocationType.OtherLocation, false, null, "31048", EmptyMessage)
+                    .SetName("And is null Then is invalid"),
+                new TestCaseData(LocationType.OtherLocation, false, new string('a', 10),  "31049", InvalidMessage)
+                    .SetName("And exceeds 9 characters Then is invalid"),
+                new TestCaseData(LocationType.OtherLocation, false, "<p>", "31049", InvalidMessage)
+                    .SetName("And contains illegal chars Then is invalid"),
+                new TestCaseData(LocationType.OtherLocation, false, "  ", "31048", EmptyMessage)
+                    .SetName("And is whitespaces Then raise not empty validation error only"),
+                new TestCaseData(LocationType.OtherLocation, true, "CV1 2WT", null, string.Empty)
+                    .SetName("And is in allowed format Then is valid"),
             };
 
         [TestCaseSource(nameof(TestCases))]
-        public void ValidatePostcode(LocationType locationType, bool isValid, string postCode, string errorCode)
+        public void ValidatePostcode(LocationType locationType, bool isValid, string postCode, string errorCode, string errorMessage)
         {
             var request = new CreateApprenticeshipRequest()
             {
@@ -27,16 +37,18 @@ namespace Esfa.Vacancy.UnitTests.CreateApprenticeship.Application.GivenACreateAp
             };
 
             var validator = new CreateApprenticeshipRequestValidator();
-
+			
             if (isValid)
             {
                 validator.ShouldNotHaveValidationErrorFor(r => r.Postcode, request);
             }
             else
             {
-                validator
+                var s = validator
                     .ShouldHaveValidationErrorFor(r => r.Postcode, request)
-                    .WithErrorCode(errorCode);
+                    .WithErrorCode(errorCode)
+                    .WithErrorMessage(errorMessage);
+                s.Count().Should().Be(1);
             }
         }
     }


### PR DESCRIPTION
In the postcode, when we enter spaces only, it is captured by NotEmpty validation. However, the regex validation complaint as well as spaces weren't allowed in the regex. I have changed the post code regex to tolerate spaces and not complaint considering it an empty input. So only one validation error is returned in this case.