### PR TITLE
RA-1549 RA-1340 Authorize request and establish employer link

### DIFF
--- a/src/Esfa.Vacancy.Api.Core/ActionFilters/ProviderAuthorisationFilter.cs
+++ b/src/Esfa.Vacancy.Api.Core/ActionFilters/ProviderAuthorisationFilter.cs
@@ -1,0 +1,40 @@
+﻿using System.Web.Http.Controllers;
+using System.Web.Http.Filters;
+using Esfa.Vacancy.Api.Core.Extensions;
+using Esfa.Vacancy.Application.Exceptions;
+
+namespace Esfa.Vacancy.Api.Core.ActionFilters
+{
+    public class ProviderAuthorisationFilter : ActionFilterAttribute
+    {
+        public override void OnActionExecuting(HttpActionContext actionContext)
+        {
+            var headerValue = actionContext.Request.GetHeaderValue(Constants.RequestHeaderNames.UserNote);
+
+            int ukprn;
+            var result = TryExtractUkprnFromHeader(headerValue, out ukprn);
+            if (!result)
+            {
+                throw new UnauthorisedException(Constants.AuthorisationErrorMessages.InvalidUkprn);
+            }
+
+            actionContext.Request.Headers.Add(Constants.RequestHeaderNames.ProviderUkprn, ukprn.ToString());
+
+            base.OnActionExecuting(actionContext);
+        }
+
+        private static bool TryExtractUkprnFromHeader(string userNoteHeader, out int providerUkprn)
+        {
+            providerUkprn = 0;
+
+            if (userNoteHeader == null) return false;
+
+            var strippedValue = userNoteHeader?
+                .ToLower()
+                .Replace(" ", string.Empty)
+                .Replace("ukprn=", string.Empty);
+
+            return int.TryParse(strippedValue, out providerUkprn);
+        }
+    }
+}

--- a/src/Esfa.Vacancy.Api.Core/Constants.cs
+++ b/src/Esfa.Vacancy.Api.Core/Constants.cs
@@ -1,0 +1,12 @@
+﻿namespace Esfa.Vacancy.Api.Core
+{
+    public static class Constants
+    {
+        public static class RequestHeaderNames
+        {
+            public const string UserId = "x-request-context-user-id";
+            public const string UserEmail = "x-request-context-user-email";
+            public const string UserNote = "x-request-context-user-note";
+        }
+    }
+}

--- a/src/Esfa.Vacancy.Api.Core/Constants.cs
+++ b/src/Esfa.Vacancy.Api.Core/Constants.cs
@@ -7,6 +7,12 @@
             public const string UserId = "x-request-context-user-id";
             public const string UserEmail = "x-request-context-user-email";
             public const string UserNote = "x-request-context-user-note";
+            public const string ProviderUkprn = "x-request-context-provider-ukprn";
+        }
+
+        public static class AuthorisationErrorMessages
+        {
+            public const string InvalidUkprn = "Your account is not linked to a valid UKPRN.";
         }
     }
 }

--- a/src/Esfa.Vacancy.Api.Core/Esfa.Vacancy.Api.Core.csproj
+++ b/src/Esfa.Vacancy.Api.Core/Esfa.Vacancy.Api.Core.csproj
@@ -64,7 +64,9 @@
     <Compile Include="..\SharedAssemblyInfo.cs">
       <Link>Properties\SharedAssemblyInfo.cs</Link>
     </Compile>
+    <Compile Include="Constants.cs" />
     <Compile Include="CustomErrorResult.cs" />
+    <Compile Include="Extensions\HttpRequestExtensions.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="RequestContext.cs" />
     <Compile Include="StrictEnumConverter.cs" />

--- a/src/Esfa.Vacancy.Api.Core/Esfa.Vacancy.Api.Core.csproj
+++ b/src/Esfa.Vacancy.Api.Core/Esfa.Vacancy.Api.Core.csproj
@@ -64,6 +64,7 @@
     <Compile Include="..\SharedAssemblyInfo.cs">
       <Link>Properties\SharedAssemblyInfo.cs</Link>
     </Compile>
+    <Compile Include="ActionFilters\ProviderAuthorisationFilter.cs" />
     <Compile Include="Constants.cs" />
     <Compile Include="CustomErrorResult.cs" />
     <Compile Include="Extensions\HttpRequestExtensions.cs" />

--- a/src/Esfa.Vacancy.Api.Core/Extensions/HttpRequestExtensions.cs
+++ b/src/Esfa.Vacancy.Api.Core/Extensions/HttpRequestExtensions.cs
@@ -10,7 +10,8 @@ namespace Esfa.Vacancy.Api.Core.Extensions
         {
             Constants.RequestHeaderNames.UserId,
             Constants.RequestHeaderNames.UserEmail,
-            Constants.RequestHeaderNames.UserNote
+            Constants.RequestHeaderNames.UserNote,
+            Constants.RequestHeaderNames.ProviderUkprn
         };
 
         public static Dictionary<string, string> GetApimUserContextHeaders(this HttpRequestMessage request)
@@ -26,7 +27,7 @@ namespace Esfa.Vacancy.Api.Core.Extensions
             return result;
         }
 
-        private static string GetHeaderValue(this HttpRequestMessage request, string header)
+        public static string GetHeaderValue(this HttpRequestMessage request, string header)
         {
             IEnumerable<string> values;
             var found = request.Headers.TryGetValues(header, out values);

--- a/src/Esfa.Vacancy.Api.Core/Extensions/HttpRequestExtensions.cs
+++ b/src/Esfa.Vacancy.Api.Core/Extensions/HttpRequestExtensions.cs
@@ -1,0 +1,40 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+using System.Net.Http;
+
+namespace Esfa.Vacancy.Api.Core.Extensions
+{
+    public static class HttpRequestExtensions
+    {
+        public static string[] Headers =
+        {
+            Constants.RequestHeaderNames.UserId,
+            Constants.RequestHeaderNames.UserEmail,
+            Constants.RequestHeaderNames.UserNote
+        };
+
+        public static Dictionary<string, string> GetApimUserContextHeaders(this HttpRequestMessage request)
+        {
+            var result = new Dictionary<string, string>();
+
+            foreach (var header in Headers)
+            {
+                var value = request.GetHeaderValue(header);
+                result.Add(header, value);
+            }
+
+            return result;
+        }
+
+        private static string GetHeaderValue(this HttpRequestMessage request, string header)
+        {
+            IEnumerable<string> values;
+            var found = request.Headers.TryGetValues(header, out values);
+            if (found)
+            {
+                return values.FirstOrDefault();
+            }
+            return null;
+        }
+    }
+}

--- a/src/Esfa.Vacancy.Api.Types/CreateApprenticeshipParameters.cs
+++ b/src/Esfa.Vacancy.Api.Types/CreateApprenticeshipParameters.cs
@@ -54,5 +54,10 @@ namespace Esfa.Vacancy.Api.Types
         /// Number of positions available for the vacancy
         /// </summary>
         public int NumberOfPositions { get; set; }
+
+        /// <summary>
+        /// Employer's unique reference number
+        /// </summary>
+        public int EmployersEdsUrn { get; set; }
     }
 }

--- a/src/Esfa.Vacancy.Api.Types/CreateApprenticeshipParameters.cs
+++ b/src/Esfa.Vacancy.Api.Types/CreateApprenticeshipParameters.cs
@@ -58,7 +58,7 @@ namespace Esfa.Vacancy.Api.Types
         /// <summary>
         /// Employer's unique reference number
         /// </summary>
-        public int EmployersEdsUrn { get; set; }
+        public int EmployerEdsUrn { get; set; }
 
         /// <summary>
         /// Provider site's unique reference number

--- a/src/Esfa.Vacancy.Api.Types/CreateApprenticeshipParameters.cs
+++ b/src/Esfa.Vacancy.Api.Types/CreateApprenticeshipParameters.cs
@@ -59,5 +59,10 @@ namespace Esfa.Vacancy.Api.Types
         /// Employer's unique reference number
         /// </summary>
         public int EmployersEdsUrn { get; set; }
+
+        /// <summary>
+        /// Provider site's unique reference number
+        /// </summary>
+        public int ProviderSiteEdsUrn { get; set; }
     }
 }

--- a/src/Esfa.Vacancy.Application/Commands/CreateApprenticeship/CreateApprenticeshipCommandHandler.cs
+++ b/src/Esfa.Vacancy.Application/Commands/CreateApprenticeship/CreateApprenticeshipCommandHandler.cs
@@ -40,12 +40,13 @@ namespace Esfa.Vacancy.Application.Commands.CreateApprenticeship
             if (!validationResult.IsValid)
                 throw new ValidationException(validationResult.Errors);
 
-            var vacancyOwnerRelationshipId = await _vacancyOwnerService.GetVacancyOwnerLinkIdAsync(message.ProviderUkprn,
+            var employerInformation = await _vacancyOwnerService.GetEmployersInformationAsync(message.ProviderUkprn,
                 message.ProviderSiteEdsUrn, message.EmployerEdsUrn);
-            if (vacancyOwnerRelationshipId == null)
+
+            if (employerInformation == null)
                 throw new UnauthorisedException(ErrorMessages.CreateApprenticeship.MissingProviderSiteEmployerLink);
 
-            var parameters = _parametersMapper.MapFromRequest(message, vacancyOwnerRelationshipId.Value);
+            var parameters = _parametersMapper.MapFromRequest(message, employerInformation);
 
             var referenceNumber = await _vacancyRepository.CreateApprenticeshipAsync(parameters);
 

--- a/src/Esfa.Vacancy.Application/Commands/CreateApprenticeship/CreateApprenticeshipParametersMapper.cs
+++ b/src/Esfa.Vacancy.Application/Commands/CreateApprenticeship/CreateApprenticeshipParametersMapper.cs
@@ -5,7 +5,7 @@ namespace Esfa.Vacancy.Application.Commands.CreateApprenticeship
     public class CreateApprenticeshipParametersMapper : ICreateApprenticeshipParametersMapper
     {
         private const int StandardLocationType = 1;
-        public CreateApprenticeshipParameters MapFromRequest(CreateApprenticeshipRequest request)
+        public CreateApprenticeshipParameters MapFromRequest(CreateApprenticeshipRequest request, int vacancyOwnerRelationshipId)
         {
             return new CreateApprenticeshipParameters
             {
@@ -24,7 +24,8 @@ namespace Esfa.Vacancy.Application.Commands.CreateApprenticeship
                 AddressLine5 = request.AddressLine5,
                 Town = request.Town,
                 Postcode = request.Postcode,
-                NumberOfPositions = request.NumberOfPositions
+                NumberOfPositions = request.NumberOfPositions,
+                VacancyOwnerRelationshipId = vacancyOwnerRelationshipId
             };
         }
     }

--- a/src/Esfa.Vacancy.Application/Commands/CreateApprenticeship/CreateApprenticeshipParametersMapper.cs
+++ b/src/Esfa.Vacancy.Application/Commands/CreateApprenticeship/CreateApprenticeshipParametersMapper.cs
@@ -5,7 +5,8 @@ namespace Esfa.Vacancy.Application.Commands.CreateApprenticeship
     public class CreateApprenticeshipParametersMapper : ICreateApprenticeshipParametersMapper
     {
         private const int StandardLocationType = 1;
-        public CreateApprenticeshipParameters MapFromRequest(CreateApprenticeshipRequest request, int vacancyOwnerRelationshipId)
+        public CreateApprenticeshipParameters MapFromRequest(CreateApprenticeshipRequest request,
+            EmployerInformation employerInformation)
         {
             return new CreateApprenticeshipParameters
             {
@@ -25,7 +26,9 @@ namespace Esfa.Vacancy.Application.Commands.CreateApprenticeship
                 Town = request.Town,
                 Postcode = request.Postcode,
                 NumberOfPositions = request.NumberOfPositions,
-                VacancyOwnerRelationshipId = vacancyOwnerRelationshipId
+                VacancyOwnerRelationshipId = employerInformation.VacancyOwnerRelationshipId.Value,
+                EmployerDescription = employerInformation.EmployerDescription,
+                EmployerWebsite = employerInformation.EmployerWebsite
             };
         }
     }

--- a/src/Esfa.Vacancy.Application/Commands/CreateApprenticeship/CreateApprenticeshipRequest.cs
+++ b/src/Esfa.Vacancy.Application/Commands/CreateApprenticeship/CreateApprenticeshipRequest.cs
@@ -21,6 +21,6 @@ namespace Esfa.Vacancy.Application.Commands.CreateApprenticeship
         public string Postcode { get; set; }
         public string Town { get; set; }
         public int NumberOfPositions { get; set; }
-        public string ProviderUkprn { get; set; }
+        public int ProviderUkprn { get; set; }
     }
 }

--- a/src/Esfa.Vacancy.Application/Commands/CreateApprenticeship/CreateApprenticeshipRequest.cs
+++ b/src/Esfa.Vacancy.Application/Commands/CreateApprenticeship/CreateApprenticeshipRequest.cs
@@ -22,5 +22,6 @@ namespace Esfa.Vacancy.Application.Commands.CreateApprenticeship
         public string Town { get; set; }
         public int NumberOfPositions { get; set; }
         public int ProviderUkprn { get; set; }
+        public int EmployersEdsUrn { get; set; }
     }
 }

--- a/src/Esfa.Vacancy.Application/Commands/CreateApprenticeship/CreateApprenticeshipRequest.cs
+++ b/src/Esfa.Vacancy.Application/Commands/CreateApprenticeship/CreateApprenticeshipRequest.cs
@@ -22,7 +22,7 @@ namespace Esfa.Vacancy.Application.Commands.CreateApprenticeship
         public string Town { get; set; }
         public int NumberOfPositions { get; set; }
         public int ProviderUkprn { get; set; }
-        public int EmployersEdsUrn { get; set; }
+        public int EmployerEdsUrn { get; set; }
         public int ProviderSiteEdsUrn { get; set; }
     }
 }

--- a/src/Esfa.Vacancy.Application/Commands/CreateApprenticeship/CreateApprenticeshipRequest.cs
+++ b/src/Esfa.Vacancy.Application/Commands/CreateApprenticeship/CreateApprenticeshipRequest.cs
@@ -23,5 +23,6 @@ namespace Esfa.Vacancy.Application.Commands.CreateApprenticeship
         public int NumberOfPositions { get; set; }
         public int ProviderUkprn { get; set; }
         public int EmployersEdsUrn { get; set; }
+        public int ProviderSiteEdsUrn { get; set; }
     }
 }

--- a/src/Esfa.Vacancy.Application/Commands/CreateApprenticeship/CreateApprenticeshipRequest.cs
+++ b/src/Esfa.Vacancy.Application/Commands/CreateApprenticeship/CreateApprenticeshipRequest.cs
@@ -21,5 +21,6 @@ namespace Esfa.Vacancy.Application.Commands.CreateApprenticeship
         public string Postcode { get; set; }
         public string Town { get; set; }
         public int NumberOfPositions { get; set; }
+        public string ProviderUkprn { get; set; }
     }
 }

--- a/src/Esfa.Vacancy.Application/Commands/CreateApprenticeship/ICreateApprenticeshipParametersMapper.cs
+++ b/src/Esfa.Vacancy.Application/Commands/CreateApprenticeship/ICreateApprenticeshipParametersMapper.cs
@@ -4,6 +4,6 @@ namespace Esfa.Vacancy.Application.Commands.CreateApprenticeship
 {
     public interface ICreateApprenticeshipParametersMapper
     {
-        CreateApprenticeshipParameters MapFromRequest(CreateApprenticeshipRequest request);
+        CreateApprenticeshipParameters MapFromRequest(CreateApprenticeshipRequest request, int i);
     }
 }

--- a/src/Esfa.Vacancy.Application/Commands/CreateApprenticeship/ICreateApprenticeshipParametersMapper.cs
+++ b/src/Esfa.Vacancy.Application/Commands/CreateApprenticeship/ICreateApprenticeshipParametersMapper.cs
@@ -4,6 +4,7 @@ namespace Esfa.Vacancy.Application.Commands.CreateApprenticeship
 {
     public interface ICreateApprenticeshipParametersMapper
     {
-        CreateApprenticeshipParameters MapFromRequest(CreateApprenticeshipRequest request, int i);
+        CreateApprenticeshipParameters MapFromRequest(CreateApprenticeshipRequest request,
+            EmployerInformation employerInformation);
     }
 }

--- a/src/Esfa.Vacancy.Application/Commands/CreateApprenticeship/Validators/CreateApprenticeshipRequestValidator.cs
+++ b/src/Esfa.Vacancy.Application/Commands/CreateApprenticeship/Validators/CreateApprenticeshipRequestValidator.cs
@@ -16,6 +16,7 @@ namespace Esfa.Vacancy.Application.Commands.CreateApprenticeship.Validators
             ConfigureLocationTypeValidator();
             ConfigureLocationValidator();
             ConfigureNumberOfPositions();
+            ConfigureKeyIdentifiers();
         }
     }
 }

--- a/src/Esfa.Vacancy.Application/Commands/CreateApprenticeship/Validators/KeyIndentifiers.cs
+++ b/src/Esfa.Vacancy.Application/Commands/CreateApprenticeship/Validators/KeyIndentifiers.cs
@@ -1,0 +1,30 @@
+﻿using Esfa.Vacancy.Domain.Validation;
+using FluentValidation;
+
+namespace Esfa.Vacancy.Application.Commands.CreateApprenticeship.Validators
+{
+    public partial class CreateApprenticeshipRequestValidator
+    {
+        private void ConfigureKeyIdentifiers()
+        {
+            RuleFor(request => request.ProviderUkprn)
+                .Cascade(CascadeMode.StopOnFirstFailure)
+                .NotEmpty()
+                .WithErrorCode(ErrorCodes.CreateApprenticeship.ProviderUkprn)
+                .GreaterThan(0)
+                .WithErrorCode(ErrorCodes.CreateApprenticeship.ProviderUkprn);
+            RuleFor(request => request.EmployerEdsUrn)
+                .Cascade(CascadeMode.StopOnFirstFailure)
+                .NotEmpty()
+                .WithErrorCode(ErrorCodes.CreateApprenticeship.EmployerEdsUrn)
+                .GreaterThan(0)
+                .WithErrorCode(ErrorCodes.CreateApprenticeship.EmployerEdsUrn);
+            RuleFor(request => request.ProviderSiteEdsUrn)
+                .Cascade(CascadeMode.StopOnFirstFailure)
+                .NotEmpty()
+                .WithErrorCode(ErrorCodes.CreateApprenticeship.ProviderSiteEdsUrn)
+                .GreaterThan(0)
+                .WithErrorCode(ErrorCodes.CreateApprenticeship.ProviderSiteEdsUrn);
+        }
+    }
+}

--- a/src/Esfa.Vacancy.Application/Esfa.Vacancy.Application.csproj
+++ b/src/Esfa.Vacancy.Application/Esfa.Vacancy.Application.csproj
@@ -78,6 +78,7 @@
     <Compile Include="Commands\CreateApprenticeship\Validators\ExpectedStartDateValidator.cs" />
     <Compile Include="Commands\CreateApprenticeship\Validators\Extensions.cs" />
     <Compile Include="Commands\CreateApprenticeship\Validators\HoursPerWeekValidator.cs" />
+    <Compile Include="Commands\CreateApprenticeship\Validators\KeyIndentifiers.cs" />
     <Compile Include="Commands\CreateApprenticeship\Validators\LocationTypeValidator.cs" />
     <Compile Include="Commands\CreateApprenticeship\Validators\LocationValidator.cs" />
     <Compile Include="Commands\CreateApprenticeship\Validators\LongDescriptionValidator.cs" />

--- a/src/Esfa.Vacancy.Domain/Entities/CreateApprenticeshipParameters.cs
+++ b/src/Esfa.Vacancy.Domain/Entities/CreateApprenticeshipParameters.cs
@@ -20,5 +20,6 @@ namespace Esfa.Vacancy.Domain.Entities
         public string Town { get; set; }
         public string Postcode { get; set; }
         public int NumberOfPositions { get; set; }
+        public int VacancyOwnerRelationshipId { get; set; }
     }
 }

--- a/src/Esfa.Vacancy.Domain/Entities/CreateApprenticeshipParameters.cs
+++ b/src/Esfa.Vacancy.Domain/Entities/CreateApprenticeshipParameters.cs
@@ -21,5 +21,7 @@ namespace Esfa.Vacancy.Domain.Entities
         public string Postcode { get; set; }
         public int NumberOfPositions { get; set; }
         public int VacancyOwnerRelationshipId { get; set; }
+        public string EmployerDescription { get; set; }
+        public string EmployerWebsite { get; set; }
     }
 }

--- a/src/Esfa.Vacancy.Domain/Entities/EmployerInformation.cs
+++ b/src/Esfa.Vacancy.Domain/Entities/EmployerInformation.cs
@@ -1,0 +1,11 @@
+﻿namespace Esfa.Vacancy.Domain.Entities
+{
+    public class EmployerInformation
+    {
+        public int? VacancyOwnerRelationshipId { get; set; }
+
+        public string EmployerDescription { get; set; }
+
+        public string EmployerWebsite { get; set; }
+    }
+}

--- a/src/Esfa.Vacancy.Domain/Esfa.Vacancy.Domain.csproj
+++ b/src/Esfa.Vacancy.Domain/Esfa.Vacancy.Domain.csproj
@@ -41,6 +41,7 @@
     <Compile Include="Entities\Address.cs" />
     <Compile Include="Entities\ApprenticeshipSummary.cs" />
     <Compile Include="Entities\CreateApprenticeshipParameters.cs" />
+    <Compile Include="Entities\EmployerInformation.cs" />
     <Compile Include="Entities\SortBy.cs" />
     <Compile Include="Entities\TraineeshipVacancy.cs" />
     <Compile Include="Entities\Framework.cs" />

--- a/src/Esfa.Vacancy.Domain/Esfa.Vacancy.Domain.csproj
+++ b/src/Esfa.Vacancy.Domain/Esfa.Vacancy.Domain.csproj
@@ -52,6 +52,7 @@
     <Compile Include="Entities\VacancyStatus.cs" />
     <Compile Include="Entities\WageType.cs" />
     <Compile Include="Interfaces\ICacheService.cs" />
+    <Compile Include="Interfaces\IVacancyOwnerService.cs" />
     <Compile Include="Validation\ErrorCodes.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Repositories\IFrameworkCodeRepository.cs" />

--- a/src/Esfa.Vacancy.Domain/Interfaces/IVacancyOwnerService.cs
+++ b/src/Esfa.Vacancy.Domain/Interfaces/IVacancyOwnerService.cs
@@ -1,9 +1,11 @@
 ﻿using System.Threading.Tasks;
+using Esfa.Vacancy.Domain.Entities;
 
 namespace Esfa.Vacancy.Domain.Interfaces
 {
     public interface IVacancyOwnerService
     {
-        Task<int?> GetVacancyOwnerLinkIdAsync(int providerUkprn, int providerSiteEdsUrn, int employerEdsUrn);
+        Task<EmployerInformation> GetEmployersInformationAsync(int providerUkprn,
+            int providerSiteEdsUrn, int employerEdsUrn);
     }
 }

--- a/src/Esfa.Vacancy.Domain/Interfaces/IVacancyOwnerService.cs
+++ b/src/Esfa.Vacancy.Domain/Interfaces/IVacancyOwnerService.cs
@@ -1,0 +1,9 @@
+﻿using System.Threading.Tasks;
+
+namespace Esfa.Vacancy.Domain.Interfaces
+{
+    public interface IVacancyOwnerService
+    {
+        Task<int?> GetVacancyOwnerLinkIdAsync(int providerUkprn, int providerSiteEdsUrn, int employerEdsUrn);
+    }
+}

--- a/src/Esfa.Vacancy.Domain/Validation/ErrorCodes.cs
+++ b/src/Esfa.Vacancy.Domain/Validation/ErrorCodes.cs
@@ -100,6 +100,10 @@
             public const string PostcodeShouldBeValid = "31049";
 
             public const string NumberOfPositions = "31201";
+
+            public const string ProviderUkprn = "31202";
+            public const string EmployerEdsUrn = "31203";
+            public const string ProviderSiteEdsUrn = "31204";
         }
     }
 }

--- a/src/Esfa.Vacancy.Domain/Validation/ErrorMessages.cs
+++ b/src/Esfa.Vacancy.Domain/Validation/ErrorMessages.cs
@@ -44,6 +44,7 @@ namespace Esfa.Vacancy.Domain.Validation
             public const string ApplicationClosingDateBeforeTomorrow = "'Application Closing Date' must be after today's date.";
             public const string ExpectedStartDateBeforeClosingDate = "'Expected Start Date' must be after the specified application closing date.";
             public const string CreateApprenticeshipParametersIsNull = "Either no request was provided or the request could not be recognised.";
+            public const string MissingProviderSiteEmployerLink = "User entry is invalid or no existing link between the provider site and employer.";
         }
         //MatchesAllowedFreeTextCharacters
     }

--- a/src/Esfa.Vacancy.Infrastructure/Esfa.Vacancy.Infrastructure.csproj
+++ b/src/Esfa.Vacancy.Infrastructure/Esfa.Vacancy.Infrastructure.csproj
@@ -116,6 +116,7 @@
     <Compile Include="Caching\AzureRedisCacheService.cs" />
     <Compile Include="Exceptions\InfrastructureException.cs" />
     <Compile Include="Factories\ElasticClientFactory.cs" />
+    <Compile Include="Factories\SqlDatabaseService.cs" />
     <Compile Include="InfrastructureRegistry.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Repositories\CachedFrameworkCodeRepository.cs" />
@@ -128,6 +129,7 @@
     <Compile Include="Services\IGeoSearchResultDistanceSetter.cs" />
     <Compile Include="Services\SearchDescriptorExtensions.cs" />
     <Compile Include="Services\TrainingDetailService.cs" />
+    <Compile Include="Services\VacancyOwnerService.cs" />
     <Compile Include="Settings\AppConfigSettingsProvider.cs" />
     <Compile Include="Settings\ApplicationSettingKeyConstants.cs" />
     <Compile Include="Settings\ApplicationSettings.cs" />

--- a/src/Esfa.Vacancy.Infrastructure/Factories/SqlDatabaseService.cs
+++ b/src/Esfa.Vacancy.Infrastructure/Factories/SqlDatabaseService.cs
@@ -1,0 +1,52 @@
+﻿using System;
+using System.Data.SqlClient;
+using System.Threading.Tasks;
+using Esfa.Vacancy.Infrastructure.Settings;
+using SFA.DAS.NLog.Logger;
+
+namespace Esfa.Vacancy.Infrastructure.Factories
+{
+    public class SqlDatabaseService
+    {
+        private readonly IProvideSettings _settings;
+        private readonly ILog _logger;
+
+        public SqlDatabaseService(IProvideSettings settings, ILog logger)
+        {
+            _settings = settings;
+            _logger = logger;
+        }
+
+        public SqlConnection GetConnection()
+        {
+            var connectionString =
+                _settings.GetSetting(ApplicationSettingKeyConstants.AvmsPlusDatabaseConnectionStringKey);
+
+            return new SqlConnection(connectionString);
+        }
+
+        public async Task<T> ExecuteWithRetryAsync<T>(string operationName, Func<SqlConnection, Task<T>> action)
+        {
+            var retry = PollyRetryPolicies.GetFixedIntervalPolicy((exception, time, retryCount, context) =>
+            {
+                _logger.Warn($"Database operation {operationName} failed with error: ({exception.Message}). Retrying... attempt {retryCount}");
+            });
+
+            var conn = GetConnection();
+
+            await conn.OpenAsync();
+
+            T result;
+            try
+            {
+                result = await retry.ExecuteAsync(() => action(conn));
+            }
+            finally
+            {
+                conn.Close();
+            }
+
+            return result;
+        }
+    }
+}

--- a/src/Esfa.Vacancy.Infrastructure/Repositories/VacancyRepository.cs
+++ b/src/Esfa.Vacancy.Infrastructure/Repositories/VacancyRepository.cs
@@ -127,7 +127,7 @@ namespace Esfa.Vacancy.Infrastructure.Repositories
                 await sqlConn.OpenAsync();
                 await sqlConn.ExecuteAsync(
                     CreateApprenticeshipVacancySqlSproc,
-                    param: dynamicParameters,
+                    dynamicParameters,
                     commandType: CommandType.StoredProcedure);
 
                 referenceNumber = dynamicParameters.Get<int>("VacancyReferenceNumber");

--- a/src/Esfa.Vacancy.Infrastructure/Services/VacancyOwnerService.cs
+++ b/src/Esfa.Vacancy.Infrastructure/Services/VacancyOwnerService.cs
@@ -2,6 +2,7 @@
 using System.Linq;
 using System.Threading.Tasks;
 using Dapper;
+using Esfa.Vacancy.Domain.Entities;
 using Esfa.Vacancy.Domain.Interfaces;
 using Esfa.Vacancy.Infrastructure.Factories;
 
@@ -10,14 +11,15 @@ namespace Esfa.Vacancy.Infrastructure.Services
     public class VacancyOwnerService : IVacancyOwnerService
     {
         private readonly SqlDatabaseService _sqlDatabaseService;
-        private const string GetVacancyOwnerRelationshipStoredProc = "[VACANCY_API].[GetVacancyOwnerRelationshipId]";
+        private const string GetVacancyOwnerRelationshipStoredProc = "[VACANCY_API].[GetEmployersInformation]";
 
         public VacancyOwnerService(SqlDatabaseService sqlDatabaseService)
         {
             _sqlDatabaseService = sqlDatabaseService;
         }
 
-        public async Task<int?> GetVacancyOwnerLinkIdAsync(int providerUkprn, int providerSiteEdsUrn, int employerEdsUrn)
+        public async Task<EmployerInformation> GetEmployersInformationAsync(int providerUkprn,
+            int providerSiteEdsUrn, int employerEdsUrn)
         {
             var result = await _sqlDatabaseService.ExecuteWithRetryAsync(
                 "Get provider site and employer's link",
@@ -27,12 +29,12 @@ namespace Esfa.Vacancy.Infrastructure.Services
                     parameters.Add("ProviderUkprn", providerUkprn, DbType.Int32);
                     parameters.Add("ProviderSiteEdsUrn", providerSiteEdsUrn, DbType.Int32);
                     parameters.Add("EmployerEdsUrn", employerEdsUrn, DbType.Int32);
-                    parameters.Add("VacancyOwnerRelationshipId", employerEdsUrn, DbType.Int32, ParameterDirection.Output);
 
-                    await sqlConn.QueryAsync<int>(GetVacancyOwnerRelationshipStoredProc, param: parameters,
+                    var results = await sqlConn.QueryAsync<EmployerInformation>(
+                        GetVacancyOwnerRelationshipStoredProc, parameters,
                         commandType: CommandType.StoredProcedure);
 
-                    return parameters.Get<int?>("VacancyOwnerRelationshipId");
+                    return results.FirstOrDefault();
                 });
             return result;
         }

--- a/src/Esfa.Vacancy.Infrastructure/Services/VacancyOwnerService.cs
+++ b/src/Esfa.Vacancy.Infrastructure/Services/VacancyOwnerService.cs
@@ -1,0 +1,40 @@
+﻿using System.Data;
+using System.Linq;
+using System.Threading.Tasks;
+using Dapper;
+using Esfa.Vacancy.Domain.Interfaces;
+using Esfa.Vacancy.Infrastructure.Factories;
+
+namespace Esfa.Vacancy.Infrastructure.Services
+{
+    public class VacancyOwnerService : IVacancyOwnerService
+    {
+        private readonly SqlDatabaseService _sqlDatabaseService;
+        private const string GetVacancyOwnerRelationshipStoredProc = "[VACANCY_API].[GetVacancyOwnerRelationshipId]";
+
+        public VacancyOwnerService(SqlDatabaseService sqlDatabaseService)
+        {
+            _sqlDatabaseService = sqlDatabaseService;
+        }
+
+        public async Task<int?> GetVacancyOwnerLinkIdAsync(int providerUkprn, int providerSiteEdsUrn, int employerEdsUrn)
+        {
+            var result = await _sqlDatabaseService.ExecuteWithRetryAsync(
+                "Get provider site and employer's link",
+                async (sqlConn) =>
+                {
+                    var parameters = new DynamicParameters();
+                    parameters.Add("ProviderUkprn", providerUkprn, DbType.Int32);
+                    parameters.Add("ProviderSiteEdsUrn", providerSiteEdsUrn, DbType.Int32);
+                    parameters.Add("EmployerEdsUrn", employerEdsUrn, DbType.Int32);
+                    parameters.Add("VacancyOwnerRelationshipId", employerEdsUrn, DbType.Int32, ParameterDirection.Output);
+
+                    await sqlConn.QueryAsync<int>(GetVacancyOwnerRelationshipStoredProc, param: parameters,
+                        commandType: CommandType.StoredProcedure);
+
+                    return parameters.Get<int?>("VacancyOwnerRelationshipId");
+                });
+            return result;
+        }
+    }
+}

--- a/src/Esfa.Vacancy.Manage.Api/Controllers/CreateApprenticeshipController.cs
+++ b/src/Esfa.Vacancy.Manage.Api/Controllers/CreateApprenticeshipController.cs
@@ -1,6 +1,7 @@
 ﻿using System.Net;
 using System.Threading.Tasks;
 using System.Web.Http;
+using Esfa.Vacancy.Api.Core.Extensions;
 using Esfa.Vacancy.Api.Types;
 using Esfa.Vacancy.Manage.Api.Orchestrators;
 using Swashbuckle.Swagger.Annotations;
@@ -75,7 +76,8 @@ namespace Esfa.Vacancy.Manage.Api.Controllers
         [SwaggerResponse(HttpStatusCode.BadRequest, "Failed request validation", typeof(BadRequestContent))]
         public async Task<IHttpActionResult> Create([FromBody]CreateApprenticeshipParameters createApprenticeshipParameters)
         {
-            var result = await _orchestrator.CreateApprenticeshipAsync(createApprenticeshipParameters);
+            var headers = Request.GetApimUserContextHeaders();
+            var result = await _orchestrator.CreateApprenticeshipAsync(createApprenticeshipParameters, headers);
             return Ok(result);
         }
     }

--- a/src/Esfa.Vacancy.Manage.Api/Controllers/CreateApprenticeshipController.cs
+++ b/src/Esfa.Vacancy.Manage.Api/Controllers/CreateApprenticeshipController.cs
@@ -1,6 +1,8 @@
 ﻿using System.Net;
+using System.Net.Http;
 using System.Threading.Tasks;
 using System.Web.Http;
+using Esfa.Vacancy.Api.Core.ActionFilters;
 using Esfa.Vacancy.Api.Core.Extensions;
 using Esfa.Vacancy.Api.Types;
 using Esfa.Vacancy.Manage.Api.Orchestrators;
@@ -70,10 +72,12 @@ namespace Esfa.Vacancy.Manage.Api.Controllers
         /// </summary>
         [HttpPost]
         [AllowAnonymous]
+        [ProviderAuthorisationFilter]
         [Route("api/v1/apprenticeships")]
         [SwaggerOperation("CreateApprenticeshipVacancy", Tags = new[] { "Apprenticeships" })]
         [SwaggerResponse(HttpStatusCode.OK, "OK", typeof(CreateApprenticeshipResponse))]
         [SwaggerResponse(HttpStatusCode.BadRequest, "Failed request validation", typeof(BadRequestContent))]
+        [SwaggerResponse(HttpStatusCode.Unauthorized, "Invalid provider ukprn", typeof(StringContent))]
         public async Task<IHttpActionResult> Create([FromBody]CreateApprenticeshipParameters createApprenticeshipParameters)
         {
             var headers = Request.GetApimUserContextHeaders();

--- a/src/Esfa.Vacancy.Manage.Api/Controllers/CreateApprenticeshipController.cs
+++ b/src/Esfa.Vacancy.Manage.Api/Controllers/CreateApprenticeshipController.cs
@@ -67,7 +67,10 @@ namespace Esfa.Vacancy.Manage.Api.Controllers
         /// | 31047       | Town can't contain invalid characters                                            |
         /// | 31048       | Postcode can't be empty when location type is other location                     |
         /// | 31049       | Postcode must be a valid UK postcode                                             |
-        /// | 31201       | Number of positions can't be empty and has to less than equal to 5000            |
+        /// | 31201       | Number of positions can't be empty and has to less than or equal to 5000         |
+        /// | 31202       | Provider's Ukprn is required to be set in the user profile                       |
+        /// | 31203       | Employer's unique reference number should be a valid positive number             |
+        /// | 31204       | Provider site's unique reference number should be a valid positive number        |
         /// 
         /// </summary>
         [HttpPost]

--- a/src/Esfa.Vacancy.Manage.Api/Mappings/CreateApprenticeshipRequestMapper.cs
+++ b/src/Esfa.Vacancy.Manage.Api/Mappings/CreateApprenticeshipRequestMapper.cs
@@ -29,7 +29,7 @@ namespace Esfa.Vacancy.Manage.Api.Mappings
                 Postcode = parameters.Location.Postcode,
                 NumberOfPositions = parameters.NumberOfPositions,
                 ProviderUkprn = providerUkprn,
-                EmployersEdsUrn = parameters.EmployersEdsUrn,
+                EmployerEdsUrn = parameters.EmployerEdsUrn,
                 ProviderSiteEdsUrn = parameters.ProviderSiteEdsUrn
             };
         }

--- a/src/Esfa.Vacancy.Manage.Api/Mappings/CreateApprenticeshipRequestMapper.cs
+++ b/src/Esfa.Vacancy.Manage.Api/Mappings/CreateApprenticeshipRequestMapper.cs
@@ -1,6 +1,4 @@
-﻿using System.Collections.Generic;
-using Esfa.Vacancy.Api.Core;
-using Esfa.Vacancy.Api.Types;
+﻿using Esfa.Vacancy.Api.Types;
 using Esfa.Vacancy.Application.Commands.CreateApprenticeship;
 using ApplicationTypes = Esfa.Vacancy.Application.Commands.CreateApprenticeship;
 
@@ -30,7 +28,8 @@ namespace Esfa.Vacancy.Manage.Api.Mappings
                 Town = parameters.Location.Town,
                 Postcode = parameters.Location.Postcode,
                 NumberOfPositions = parameters.NumberOfPositions,
-                ProviderUkprn = providerUkprn
+                ProviderUkprn = providerUkprn,
+                EmployersEdsUrn = parameters.EmployersEdsUrn
             };
         }
     }

--- a/src/Esfa.Vacancy.Manage.Api/Mappings/CreateApprenticeshipRequestMapper.cs
+++ b/src/Esfa.Vacancy.Manage.Api/Mappings/CreateApprenticeshipRequestMapper.cs
@@ -29,7 +29,8 @@ namespace Esfa.Vacancy.Manage.Api.Mappings
                 Postcode = parameters.Location.Postcode,
                 NumberOfPositions = parameters.NumberOfPositions,
                 ProviderUkprn = providerUkprn,
-                EmployersEdsUrn = parameters.EmployersEdsUrn
+                EmployersEdsUrn = parameters.EmployersEdsUrn,
+                ProviderSiteEdsUrn = parameters.ProviderSiteEdsUrn
             };
         }
     }

--- a/src/Esfa.Vacancy.Manage.Api/Mappings/CreateApprenticeshipRequestMapper.cs
+++ b/src/Esfa.Vacancy.Manage.Api/Mappings/CreateApprenticeshipRequestMapper.cs
@@ -10,7 +10,7 @@ namespace Esfa.Vacancy.Manage.Api.Mappings
     {
         public CreateApprenticeshipRequest MapFromApiParameters(
             CreateApprenticeshipParameters parameters,
-            Dictionary<string, string> requestHeaders)
+            int providerUkprn)
         {
             return new CreateApprenticeshipRequest
             {
@@ -30,15 +30,8 @@ namespace Esfa.Vacancy.Manage.Api.Mappings
                 Town = parameters.Location.Town,
                 Postcode = parameters.Location.Postcode,
                 NumberOfPositions = parameters.NumberOfPositions,
-                ProviderUkprn =
-                    GetProvidersUkprnFromHeaderValue(
-                        requestHeaders[Constants.RequestHeaderNames.UserNote])
+                ProviderUkprn = providerUkprn
             };
-        }
-
-        private static string GetProvidersUkprnFromHeaderValue(string headerValue)
-        {
-            return headerValue?.Replace("UKPRN=", string.Empty);
         }
     }
 }

--- a/src/Esfa.Vacancy.Manage.Api/Mappings/CreateApprenticeshipRequestMapper.cs
+++ b/src/Esfa.Vacancy.Manage.Api/Mappings/CreateApprenticeshipRequestMapper.cs
@@ -1,4 +1,6 @@
-﻿using Esfa.Vacancy.Api.Types;
+﻿using System.Collections.Generic;
+using Esfa.Vacancy.Api.Core;
+using Esfa.Vacancy.Api.Types;
 using Esfa.Vacancy.Application.Commands.CreateApprenticeship;
 using ApplicationTypes = Esfa.Vacancy.Application.Commands.CreateApprenticeship;
 
@@ -6,7 +8,9 @@ namespace Esfa.Vacancy.Manage.Api.Mappings
 {
     public class CreateApprenticeshipRequestMapper : ICreateApprenticeshipRequestMapper
     {
-        public CreateApprenticeshipRequest MapFromApiParameters(CreateApprenticeshipParameters parameters)
+        public CreateApprenticeshipRequest MapFromApiParameters(
+            CreateApprenticeshipParameters parameters,
+            Dictionary<string, string> requestHeaders)
         {
             return new CreateApprenticeshipRequest
             {
@@ -25,8 +29,16 @@ namespace Esfa.Vacancy.Manage.Api.Mappings
                 AddressLine5 = parameters.Location.AddressLine5,
                 Town = parameters.Location.Town,
                 Postcode = parameters.Location.Postcode,
-                NumberOfPositions = parameters.NumberOfPositions
+                NumberOfPositions = parameters.NumberOfPositions,
+                ProviderUkprn =
+                    GetProvidersUkprnFromHeaderValue(
+                        requestHeaders[Constants.RequestHeaderNames.UserNote])
             };
+        }
+
+        private static string GetProvidersUkprnFromHeaderValue(string headerValue)
+        {
+            return headerValue?.Replace("UKPRN=", string.Empty);
         }
     }
 }

--- a/src/Esfa.Vacancy.Manage.Api/Mappings/ICreateApprenticeshipRequestMapper.cs
+++ b/src/Esfa.Vacancy.Manage.Api/Mappings/ICreateApprenticeshipRequestMapper.cs
@@ -1,4 +1,4 @@
-﻿using System.Collections.Generic;
+﻿using Esfa.Vacancy.Api.Types;
 using Esfa.Vacancy.Application.Commands.CreateApprenticeship;
 
 namespace Esfa.Vacancy.Manage.Api.Mappings
@@ -6,7 +6,7 @@ namespace Esfa.Vacancy.Manage.Api.Mappings
     public interface ICreateApprenticeshipRequestMapper
     {
         CreateApprenticeshipRequest MapFromApiParameters(
-            Vacancy.Api.Types.CreateApprenticeshipParameters parameters,
-            Dictionary<string, string> headers);
+            CreateApprenticeshipParameters parameters,
+            int providerUkprn);
     }
 }

--- a/src/Esfa.Vacancy.Manage.Api/Mappings/ICreateApprenticeshipRequestMapper.cs
+++ b/src/Esfa.Vacancy.Manage.Api/Mappings/ICreateApprenticeshipRequestMapper.cs
@@ -1,9 +1,12 @@
-﻿using Esfa.Vacancy.Application.Commands.CreateApprenticeship;
+﻿using System.Collections.Generic;
+using Esfa.Vacancy.Application.Commands.CreateApprenticeship;
 
 namespace Esfa.Vacancy.Manage.Api.Mappings
 {
     public interface ICreateApprenticeshipRequestMapper
     {
-        CreateApprenticeshipRequest MapFromApiParameters(Vacancy.Api.Types.CreateApprenticeshipParameters parameters);
+        CreateApprenticeshipRequest MapFromApiParameters(
+            Vacancy.Api.Types.CreateApprenticeshipParameters parameters,
+            Dictionary<string, string> headers);
     }
 }

--- a/src/Esfa.Vacancy.Manage.Api/Orchestrators/CreateApprenticeshipOrchestrator.cs
+++ b/src/Esfa.Vacancy.Manage.Api/Orchestrators/CreateApprenticeshipOrchestrator.cs
@@ -1,4 +1,5 @@
-﻿using System.Threading.Tasks;
+﻿using System.Collections.Generic;
+using System.Threading.Tasks;
 using Esfa.Vacancy.Api.Core.Validation;
 using Esfa.Vacancy.Api.Types;
 using Esfa.Vacancy.Domain.Validation;
@@ -26,7 +27,8 @@ namespace Esfa.Vacancy.Manage.Api.Orchestrators
             _validationExceptionBuilder = validationExceptionBuilder;
         }
 
-        public async Task<CreateApprenticeshipResponse> CreateApprenticeshipAsync(CreateApprenticeshipParameters parameters)
+        public async Task<CreateApprenticeshipResponse> CreateApprenticeshipAsync(
+            CreateApprenticeshipParameters parameters, Dictionary<string, string> headers)
         {
             if (parameters == null)
             {
@@ -36,7 +38,10 @@ namespace Esfa.Vacancy.Manage.Api.Orchestrators
                     CreateApprenticeshipParametersName);
             }
 
-            var request = _createApprenticeshipRequestMapper.MapFromApiParameters(parameters);
+            var request = _createApprenticeshipRequestMapper.MapFromApiParameters(parameters, headers);
+
+
+
             var response = await _mediator.Send(request);
             return _apprenticeshipResponseMapper.MapToApiResponse(response);
         }

--- a/src/Esfa.Vacancy.Manage.Api/Orchestrators/CreateApprenticeshipOrchestrator.cs
+++ b/src/Esfa.Vacancy.Manage.Api/Orchestrators/CreateApprenticeshipOrchestrator.cs
@@ -3,7 +3,6 @@ using System.Threading.Tasks;
 using Esfa.Vacancy.Api.Core;
 using Esfa.Vacancy.Api.Core.Validation;
 using Esfa.Vacancy.Api.Types;
-using Esfa.Vacancy.Application.Exceptions;
 using Esfa.Vacancy.Domain.Validation;
 using Esfa.Vacancy.Manage.Api.Mappings;
 using MediatR;
@@ -40,27 +39,12 @@ namespace Esfa.Vacancy.Manage.Api.Orchestrators
                     CreateApprenticeshipParametersName);
             }
 
-            int ukprn;
-            var result = TryExtractUkprnFromHeader(requestHeaders[Constants.RequestHeaderNames.UserNote], out ukprn);
-            if (!result)
-            {
-                throw new UnauthorisedException("Your account is not linked to a valid UKPRN.");
-            }
+            var ukprn = int.Parse(requestHeaders[Constants.RequestHeaderNames.ProviderUkprn]);
 
             var request = _createApprenticeshipRequestMapper.MapFromApiParameters(parameters, ukprn);
 
             var response = await _mediator.Send(request);
             return _apprenticeshipResponseMapper.MapToApiResponse(response);
-        }
-
-        private static bool TryExtractUkprnFromHeader(string userNoteHeader, out int providerUkprn)
-        {
-            var strippedValue = userNoteHeader?
-                .ToLower()
-                .Replace(" ", string.Empty)
-                .Replace("ukprn=", string.Empty);
-
-            return int.TryParse(strippedValue, out providerUkprn);
         }
     }
 }

--- a/src/Esfa.Vacancy.UnitTests/CreateApprenticeship/Api/Mappings/GivenACreateApprenticeshipRequestMapper/WhenMappingFromApiParameters.cs
+++ b/src/Esfa.Vacancy.UnitTests/CreateApprenticeship/Api/Mappings/GivenACreateApprenticeshipRequestMapper/WhenMappingFromApiParameters.cs
@@ -131,7 +131,7 @@ namespace Esfa.Vacancy.UnitTests.CreateApprenticeship.Api.Mappings.GivenACreateA
         [Test]
         public void ThenMapsEmployersEdsUrn()
         {
-            _mappedRequest.EmployersEdsUrn.Should().Be(_apiParameters.EmployersEdsUrn);
+            _mappedRequest.EmployerEdsUrn.Should().Be(_apiParameters.EmployerEdsUrn);
         }
 
         [Test]

--- a/src/Esfa.Vacancy.UnitTests/CreateApprenticeship/Api/Mappings/GivenACreateApprenticeshipRequestMapper/WhenMappingFromApiParameters.cs
+++ b/src/Esfa.Vacancy.UnitTests/CreateApprenticeship/Api/Mappings/GivenACreateApprenticeshipRequestMapper/WhenMappingFromApiParameters.cs
@@ -127,5 +127,11 @@ namespace Esfa.Vacancy.UnitTests.CreateApprenticeship.Api.Mappings.GivenACreateA
         {
             _mappedRequest.ProviderUkprn.Should().Be(_ukprn);
         }
+
+        [Test]
+        public void ThenMapsEmployersEdsUrn()
+        {
+            _mappedRequest.EmployersEdsUrn.Should().Be(_apiParameters.EmployersEdsUrn);
+        }
     }
 }

--- a/src/Esfa.Vacancy.UnitTests/CreateApprenticeship/Api/Mappings/GivenACreateApprenticeshipRequestMapper/WhenMappingFromApiParameters.cs
+++ b/src/Esfa.Vacancy.UnitTests/CreateApprenticeship/Api/Mappings/GivenACreateApprenticeshipRequestMapper/WhenMappingFromApiParameters.cs
@@ -133,5 +133,11 @@ namespace Esfa.Vacancy.UnitTests.CreateApprenticeship.Api.Mappings.GivenACreateA
         {
             _mappedRequest.EmployersEdsUrn.Should().Be(_apiParameters.EmployersEdsUrn);
         }
+
+        [Test]
+        public void ThenMapsProviderSiteEdsUrn()
+        {
+            _mappedRequest.ProviderSiteEdsUrn.Should().Be(_apiParameters.ProviderSiteEdsUrn);
+        }
     }
 }

--- a/src/Esfa.Vacancy.UnitTests/CreateApprenticeship/Api/Mappings/GivenACreateApprenticeshipRequestMapper/WhenMappingFromApiParameters.cs
+++ b/src/Esfa.Vacancy.UnitTests/CreateApprenticeship/Api/Mappings/GivenACreateApprenticeshipRequestMapper/WhenMappingFromApiParameters.cs
@@ -1,4 +1,6 @@
-﻿using Esfa.Vacancy.Api.Types;
+﻿using System.Collections.Generic;
+using Esfa.Vacancy.Api.Core;
+using Esfa.Vacancy.Api.Types;
 using Esfa.Vacancy.Application.Commands.CreateApprenticeship;
 using Esfa.Vacancy.Manage.Api.Mappings;
 using FluentAssertions;
@@ -20,9 +22,12 @@ namespace Esfa.Vacancy.UnitTests.CreateApprenticeship.Api.Mappings.GivenACreateA
             var fixture = new Fixture();
             _apiParameters = fixture.Create<CreateApprenticeshipParameters>();
 
+            var headers =
+                new Dictionary<string, string> {{Constants.RequestHeaderNames.UserNote, "UKPRN=12345678"}};
+
             var mapper = new CreateApprenticeshipRequestMapper();
 
-            _mappedRequest = mapper.MapFromApiParameters(_apiParameters);
+            _mappedRequest = mapper.MapFromApiParameters(_apiParameters, headers);
         }
 
         [Test]
@@ -119,6 +124,12 @@ namespace Esfa.Vacancy.UnitTests.CreateApprenticeship.Api.Mappings.GivenACreateA
         public void ThenMapsNumberOfPositions()
         {
             _mappedRequest.NumberOfPositions.Should().Be(_apiParameters.NumberOfPositions);
+        }
+
+        [Test]
+        public void ThenMapsUkprnFromTheHeader()
+        {
+            _mappedRequest.ProviderUkprn.Should().Be("12345678");
         }
     }
 }

--- a/src/Esfa.Vacancy.UnitTests/CreateApprenticeship/Api/Mappings/GivenACreateApprenticeshipRequestMapper/WhenMappingFromApiParameters.cs
+++ b/src/Esfa.Vacancy.UnitTests/CreateApprenticeship/Api/Mappings/GivenACreateApprenticeshipRequestMapper/WhenMappingFromApiParameters.cs
@@ -15,6 +15,7 @@ namespace Esfa.Vacancy.UnitTests.CreateApprenticeship.Api.Mappings.GivenACreateA
     {
         private CreateApprenticeshipParameters _apiParameters;
         private CreateApprenticeshipRequest _mappedRequest;
+        private int _ukprn = 12345678;
 
         [SetUp]
         public void SetUp()
@@ -23,11 +24,11 @@ namespace Esfa.Vacancy.UnitTests.CreateApprenticeship.Api.Mappings.GivenACreateA
             _apiParameters = fixture.Create<CreateApprenticeshipParameters>();
 
             var headers =
-                new Dictionary<string, string> {{Constants.RequestHeaderNames.UserNote, "UKPRN=12345678"}};
+                new Dictionary<string, string> { { Constants.RequestHeaderNames.UserNote, "UKPRN=12345678" } };
 
             var mapper = new CreateApprenticeshipRequestMapper();
 
-            _mappedRequest = mapper.MapFromApiParameters(_apiParameters, headers);
+            _mappedRequest = mapper.MapFromApiParameters(_apiParameters, _ukprn);
         }
 
         [Test]
@@ -127,9 +128,9 @@ namespace Esfa.Vacancy.UnitTests.CreateApprenticeship.Api.Mappings.GivenACreateA
         }
 
         [Test]
-        public void ThenMapsUkprnFromTheHeader()
+        public void ThenMapsProviderUkprn()
         {
-            _mappedRequest.ProviderUkprn.Should().Be("12345678");
+            _mappedRequest.ProviderUkprn.Should().Be(_ukprn);
         }
     }
 }

--- a/src/Esfa.Vacancy.UnitTests/CreateApprenticeship/Api/Mappings/GivenACreateApprenticeshipRequestMapper/WhenMappingFromApiParameters.cs
+++ b/src/Esfa.Vacancy.UnitTests/CreateApprenticeship/Api/Mappings/GivenACreateApprenticeshipRequestMapper/WhenMappingFromApiParameters.cs
@@ -1,6 +1,4 @@
-﻿using System.Collections.Generic;
-using Esfa.Vacancy.Api.Core;
-using Esfa.Vacancy.Api.Types;
+﻿using Esfa.Vacancy.Api.Types;
 using Esfa.Vacancy.Application.Commands.CreateApprenticeship;
 using Esfa.Vacancy.Manage.Api.Mappings;
 using FluentAssertions;
@@ -22,9 +20,6 @@ namespace Esfa.Vacancy.UnitTests.CreateApprenticeship.Api.Mappings.GivenACreateA
         {
             var fixture = new Fixture();
             _apiParameters = fixture.Create<CreateApprenticeshipParameters>();
-
-            var headers =
-                new Dictionary<string, string> { { Constants.RequestHeaderNames.UserNote, "UKPRN=12345678" } };
 
             var mapper = new CreateApprenticeshipRequestMapper();
 

--- a/src/Esfa.Vacancy.UnitTests/CreateApprenticeship/Api/Orchestrators/GivenACreateApprenticeshipOrchestrator/WhenCreatingAnApprenticeshipVacancy.cs
+++ b/src/Esfa.Vacancy.UnitTests/CreateApprenticeship/Api/Orchestrators/GivenACreateApprenticeshipOrchestrator/WhenCreatingAnApprenticeshipVacancy.cs
@@ -23,6 +23,7 @@ namespace Esfa.Vacancy.UnitTests.CreateApprenticeship.Api.Orchestrators.GivenACr
     [TestFixture]
     public class WhenCreatingAnApprenticeshipVacancy
     {
+        private const int providerUkprn = 12345678;
         private Mock<IMediator> _mockMediator;
         private ApiTypes.CreateApprenticeshipResponse _actualResponse;
         private CreateApprenticeshipResponse _expectedMediatorResponse;
@@ -35,7 +36,7 @@ namespace Esfa.Vacancy.UnitTests.CreateApprenticeship.Api.Orchestrators.GivenACr
         private Mock<IValidationExceptionBuilder> _mockValidationExceptionBuilder;
         private string _expectedErrorMessage;
         private Dictionary<string, string> _validHeader
-            = new Dictionary<string, string> { { Constants.RequestHeaderNames.ProviderUkprn, "12345678" } };
+            = new Dictionary<string, string> { { Constants.RequestHeaderNames.ProviderUkprn, providerUkprn.ToString() } };
 
         [SetUp]
         public async Task SetUp()
@@ -113,7 +114,7 @@ namespace Esfa.Vacancy.UnitTests.CreateApprenticeship.Api.Orchestrators.GivenACr
         [Test]
         public void ThenInvokeRequestMapperWithInputParameters()
         {
-            _mockRequestMapper.Verify(mapper => mapper.MapFromApiParameters(_actualParameters, 12345678));
+            _mockRequestMapper.Verify(mapper => mapper.MapFromApiParameters(_actualParameters, providerUkprn));
         }
     }
 }

--- a/src/Esfa.Vacancy.UnitTests/CreateApprenticeship/Api/Orchestrators/GivenACreateApprenticeshipOrchestrator/WhenCreatingAnApprenticeshipVacancy.cs
+++ b/src/Esfa.Vacancy.UnitTests/CreateApprenticeship/Api/Orchestrators/GivenACreateApprenticeshipOrchestrator/WhenCreatingAnApprenticeshipVacancy.cs
@@ -5,7 +5,6 @@ using System.Threading.Tasks;
 using Esfa.Vacancy.Api.Core;
 using Esfa.Vacancy.Api.Core.Validation;
 using Esfa.Vacancy.Application.Commands.CreateApprenticeship;
-using Esfa.Vacancy.Application.Exceptions;
 using Esfa.Vacancy.Domain.Validation;
 using Esfa.Vacancy.Manage.Api.Mappings;
 using Esfa.Vacancy.Manage.Api.Orchestrators;
@@ -36,7 +35,7 @@ namespace Esfa.Vacancy.UnitTests.CreateApprenticeship.Api.Orchestrators.GivenACr
         private Mock<IValidationExceptionBuilder> _mockValidationExceptionBuilder;
         private string _expectedErrorMessage;
         private Dictionary<string, string> _validHeader
-            = new Dictionary<string, string> { { Constants.RequestHeaderNames.UserNote, "ukprn=12345678" } };
+            = new Dictionary<string, string> { { Constants.RequestHeaderNames.ProviderUkprn, "12345678" } };
 
         [SetUp]
         public async Task SetUp()
@@ -93,31 +92,6 @@ namespace Esfa.Vacancy.UnitTests.CreateApprenticeship.Api.Orchestrators.GivenACr
                     It.IsAny<string>()), Times.Once);
         }
 
-        [TestCase(null, false, TestName = "And is missing Then raise unauthorised exception")]
-        [TestCase("null", false, TestName = "And is unexpected value Then raise unauthorised exception")]
-        [TestCase("UkpRn=12345678", true, TestName = "And is correct format in mix case Then is fine")]
-        [TestCase("UkpRn = 12345678", true, TestName = "And is correct format with spaces Then is fine")]
-        public void ValidateUkprn(string headerValue, bool isValid)
-        {
-            var headers =
-                new Dictionary<string, string> { { Constants.RequestHeaderNames.UserNote, headerValue } };
-
-            Func<Task> action = async () =>
-            {
-                await _orchestrator.CreateApprenticeshipAsync(_actualParameters, headers);
-            };
-
-            if (isValid)
-            {
-                action.ShouldNotThrow<UnauthorisedException>();
-            }
-            else
-            {
-                action.ShouldThrow<UnauthorisedException>()
-                    .WithMessage($"Your account is not linked to a valid UKPRN.");
-            }
-        }
-
         [Test]
         public void ThenSendCommandToMediator()
         {
@@ -139,7 +113,7 @@ namespace Esfa.Vacancy.UnitTests.CreateApprenticeship.Api.Orchestrators.GivenACr
         [Test]
         public void ThenInvokeRequestMapperWithInputParameters()
         {
-            _mockRequestMapper.Verify(mapper => mapper.MapFromApiParameters(_actualParameters, It.IsAny<int>()));
+            _mockRequestMapper.Verify(mapper => mapper.MapFromApiParameters(_actualParameters, 12345678));
         }
     }
 }

--- a/src/Esfa.Vacancy.UnitTests/CreateApprenticeship/Api/Orchestrators/GivenACreateApprenticeshipOrchestrator/WhenCreatingAnApprenticeshipVacancy.cs
+++ b/src/Esfa.Vacancy.UnitTests/CreateApprenticeship/Api/Orchestrators/GivenACreateApprenticeshipOrchestrator/WhenCreatingAnApprenticeshipVacancy.cs
@@ -47,7 +47,7 @@ namespace Esfa.Vacancy.UnitTests.CreateApprenticeship.Api.Orchestrators.GivenACr
             _expectedErrorMessage = fixture.Create<string>();
 
             _mockRequestMapper = fixture.Freeze<Mock<ICreateApprenticeshipRequestMapper>>(composer => composer.Do(mock => mock
-                .Setup(mapper => mapper.MapFromApiParameters(_actualParameters))
+                .Setup(mapper => mapper.MapFromApiParameters(_actualParameters, It.IsAny<Dictionary<string, string>>()))
                 .Returns(_expectedRequest)));
 
             _mockMediator = fixture.Freeze<Mock<IMediator>>(composer => composer.Do(mock => mock
@@ -68,7 +68,7 @@ namespace Esfa.Vacancy.UnitTests.CreateApprenticeship.Api.Orchestrators.GivenACr
 
             _orchestrator = fixture.Create<CreateApprenticeshipOrchestrator>();
 
-            _actualResponse = await _orchestrator.CreateApprenticeshipAsync(_actualParameters);
+            _actualResponse = await _orchestrator.CreateApprenticeshipAsync(_actualParameters, It.IsAny<Dictionary<string, string>>());
         }
 
         [Test]
@@ -76,7 +76,7 @@ namespace Esfa.Vacancy.UnitTests.CreateApprenticeship.Api.Orchestrators.GivenACr
         {
             Func<Task> action = async () =>
             {
-                await _orchestrator.CreateApprenticeshipAsync(null);
+                await _orchestrator.CreateApprenticeshipAsync(null, It.IsAny<Dictionary<string, string>>());
             };
 
             action.ShouldThrow<ValidationException>()
@@ -110,7 +110,7 @@ namespace Esfa.Vacancy.UnitTests.CreateApprenticeship.Api.Orchestrators.GivenACr
         [Test]
         public void ThenInvokeRequestMapperWithInputParameters()
         {
-            _mockRequestMapper.Verify(mapper => mapper.MapFromApiParameters(_actualParameters));
+            _mockRequestMapper.Verify(mapper => mapper.MapFromApiParameters(_actualParameters, It.IsAny<Dictionary<string, string>>()));
         }
     }
 }

--- a/src/Esfa.Vacancy.UnitTests/CreateApprenticeship/Application/GivenACreateApprenticeshipCommandHandler/WhenHandlingACommand.cs
+++ b/src/Esfa.Vacancy.UnitTests/CreateApprenticeship/Application/GivenACreateApprenticeshipCommandHandler/WhenHandlingACommand.cs
@@ -103,18 +103,12 @@ namespace Esfa.Vacancy.UnitTests.CreateApprenticeship.Application.GivenACreateAp
         [Test]
         public void AndIfLinkIsNotRetrieved_ThenThrowUnauthorisedException()
         {
-            var validRequest = _fixture.Create<CreateApprenticeshipRequest>();
-
-            _mockValidator
-                .Setup(validator => validator.ValidateAsync(validRequest, It.IsAny<CancellationToken>()))
-                .ReturnsAsync(new ValidationResult());
-
             _mockVacancyOwnerService
                 .Setup(svc => svc.GetEmployersInformationAsync(
                     It.IsAny<int>(), It.IsAny<int>(), It.IsAny<int>()))
                 .ReturnsAsync((EmployerInformation)null);
 
-            var action = new Func<Task<CreateApprenticeshipResponse>>(() => _handler.Handle(validRequest));
+            var action = new Func<Task<CreateApprenticeshipResponse>>(() => _handler.Handle(_validRequest));
             action.ShouldThrow<UnauthorisedException>()
                 .WithMessage(ErrorMessages.CreateApprenticeship.MissingProviderSiteEmployerLink);
         }

--- a/src/Esfa.Vacancy.UnitTests/CreateApprenticeship/Application/GivenACreateApprenticeshipCommandHandler/WhenHandlingACommand.cs
+++ b/src/Esfa.Vacancy.UnitTests/CreateApprenticeship/Application/GivenACreateApprenticeshipCommandHandler/WhenHandlingACommand.cs
@@ -3,8 +3,11 @@ using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
 using Esfa.Vacancy.Application.Commands.CreateApprenticeship;
+using Esfa.Vacancy.Application.Exceptions;
 using Esfa.Vacancy.Domain.Entities;
+using Esfa.Vacancy.Domain.Interfaces;
 using Esfa.Vacancy.Domain.Repositories;
+using Esfa.Vacancy.Domain.Validation;
 using FluentAssertions;
 using FluentValidation;
 using FluentValidation.Results;
@@ -18,6 +21,7 @@ namespace Esfa.Vacancy.UnitTests.CreateApprenticeship.Application.GivenACreateAp
     [TestFixture]
     public class WhenHandlingACommand
     {
+        private const int VacancyOwnerRelationshipId = 1;
         private CreateApprenticeshipResponse _createApprenticeshipResponse;
         private int _expectedRefNumber;
         private Mock<IValidator<CreateApprenticeshipRequest>> _mockValidator;
@@ -27,6 +31,7 @@ namespace Esfa.Vacancy.UnitTests.CreateApprenticeship.Application.GivenACreateAp
         private Mock<IVacancyRepository> _mockRepository;
         private CreateApprenticeshipRequest _validRequest;
         private CreateApprenticeshipParameters _expectedParameters;
+        private Mock<IVacancyOwnerService> _mockVacancyOwnerService;
 
         [SetUp]
         public async Task SetUp()
@@ -42,8 +47,13 @@ namespace Esfa.Vacancy.UnitTests.CreateApprenticeship.Application.GivenACreateAp
                 .Setup(validator => validator.ValidateAsync(_validRequest, It.IsAny<CancellationToken>()))
                 .ReturnsAsync(new ValidationResult());
 
+            _mockVacancyOwnerService = _fixture.Freeze<Mock<IVacancyOwnerService>>();
+            _mockVacancyOwnerService
+                .Setup(svc => svc.GetVacancyOwnerLinkIdAsync(It.IsAny<int>(), It.IsAny<int>(), It.IsAny<int>()))
+                .ReturnsAsync(VacancyOwnerRelationshipId);
+
             _mockMapper = _fixture.Freeze<Mock<ICreateApprenticeshipParametersMapper>>(composer => composer.Do(mock => mock
-                .Setup(mapper => mapper.MapFromRequest(It.IsAny<CreateApprenticeshipRequest>()))
+                .Setup(mapper => mapper.MapFromRequest(It.IsAny<CreateApprenticeshipRequest>(), It.IsAny<int>()))
                 .Returns(_expectedParameters)));
 
             _mockRepository = _fixture.Freeze<Mock<IVacancyRepository>>(composer => composer.Do(mock => mock
@@ -77,23 +87,47 @@ namespace Esfa.Vacancy.UnitTests.CreateApprenticeship.Application.GivenACreateAp
         [Test]
         public void ThenValidatesRequest()
         {
-            _mockValidator.Verify(validator => 
+            _mockValidator.Verify(validator =>
                 validator.ValidateAsync(_validRequest, It.IsAny<CancellationToken>()),
                 Times.Once);
         }
 
         [Test]
+        public void ThenFetchVacancyOwnerLink()
+        {
+            _mockVacancyOwnerService.Verify(svc => svc.GetVacancyOwnerLinkIdAsync(It.IsAny<int>(), It.IsAny<int>(), It.IsAny<int>()));
+        }
+
+        [Test]
+        public void AndIfLinkIsNotRetrieved_ThenThrowUnauthorisedException()
+        {
+            var validRequest = _fixture.Create<CreateApprenticeshipRequest>();
+
+            _mockValidator
+                .Setup(validator => validator.ValidateAsync(validRequest, It.IsAny<CancellationToken>()))
+                .ReturnsAsync(new ValidationResult());
+
+            _mockVacancyOwnerService
+                .Setup(svc => svc.GetVacancyOwnerLinkIdAsync(It.IsAny<int>(), It.IsAny<int>(), It.IsAny<int>()))
+                .ReturnsAsync((int?)null);
+
+            var action = new Func<Task<CreateApprenticeshipResponse>>(() => _handler.Handle(validRequest));
+            action.ShouldThrow<UnauthorisedException>()
+                .WithMessage(ErrorMessages.CreateApprenticeship.MissingProviderSiteEmployerLink);
+        }
+
+        [Test]
         public void ThenMapsRequestToCreateParams()
         {
-            _mockMapper.Verify(mapper => 
-                mapper.MapFromRequest(_validRequest),
+            _mockMapper.Verify(mapper =>
+                mapper.MapFromRequest(_validRequest, VacancyOwnerRelationshipId),
                 Times.Once);
         }
 
         [Test]
         public void ThenCreatesVacancy()
         {
-            _mockRepository.Verify(repository => 
+            _mockRepository.Verify(repository =>
                 repository.CreateApprenticeshipAsync(_expectedParameters),
                 Times.Once);
         }

--- a/src/Esfa.Vacancy.UnitTests/CreateApprenticeship/Application/GivenACreateApprenticeshipParametersMapper/WhenMappingFromARequest.cs
+++ b/src/Esfa.Vacancy.UnitTests/CreateApprenticeship/Application/GivenACreateApprenticeshipParametersMapper/WhenMappingFromARequest.cs
@@ -9,7 +9,7 @@ namespace Esfa.Vacancy.UnitTests.CreateApprenticeship.Application.GivenACreateAp
     [TestFixture]
     public class WhenMappingFromARequest
     {
-        private const int VacancyOwnerRelationshipId = 1;
+        private EmployerInformation _employerInformation;
         private CreateApprenticeshipParameters _mappedParameters;
         private CreateApprenticeshipRequest _request;
 
@@ -20,9 +20,11 @@ namespace Esfa.Vacancy.UnitTests.CreateApprenticeship.Application.GivenACreateAp
             var fixture = new Fixture();
             _request = fixture.Create<CreateApprenticeshipRequest>();
 
+            _employerInformation = fixture.Create<EmployerInformation>();
+
             var mapper = fixture.Create<CreateApprenticeshipParametersMapper>();
 
-            _mappedParameters = mapper.MapFromRequest(_request, VacancyOwnerRelationshipId);
+            _mappedParameters = mapper.MapFromRequest(_request, _employerInformation);
         }
 
         [Test]
@@ -118,7 +120,22 @@ namespace Esfa.Vacancy.UnitTests.CreateApprenticeship.Application.GivenACreateAp
         [Test]
         public void ThenMapsVacancyOwnerRelationshipId()
         {
-            _mappedParameters.VacancyOwnerRelationshipId.Should().Be(VacancyOwnerRelationshipId);
+            _mappedParameters.VacancyOwnerRelationshipId
+                .Should().Be(_employerInformation.VacancyOwnerRelationshipId);
+        }
+
+        [Test]
+        public void ThenMapsEmployerDescription()
+        {
+            _mappedParameters.EmployerDescription
+                .Should().Be(_employerInformation.EmployerDescription);
+        }
+
+        [Test]
+        public void ThenMapsEmployerWebsite()
+        {
+            _mappedParameters.EmployerWebsite
+                .Should().Be(_employerInformation.EmployerWebsite);
         }
     }
 }

--- a/src/Esfa.Vacancy.UnitTests/CreateApprenticeship/Application/GivenACreateApprenticeshipParametersMapper/WhenMappingFromARequest.cs
+++ b/src/Esfa.Vacancy.UnitTests/CreateApprenticeship/Application/GivenACreateApprenticeshipParametersMapper/WhenMappingFromARequest.cs
@@ -9,8 +9,10 @@ namespace Esfa.Vacancy.UnitTests.CreateApprenticeship.Application.GivenACreateAp
     [TestFixture]
     public class WhenMappingFromARequest
     {
+        private const int VacancyOwnerRelationshipId = 1;
         private CreateApprenticeshipParameters _mappedParameters;
         private CreateApprenticeshipRequest _request;
+
 
         [SetUp]
         public void SetUp()
@@ -20,7 +22,7 @@ namespace Esfa.Vacancy.UnitTests.CreateApprenticeship.Application.GivenACreateAp
 
             var mapper = fixture.Create<CreateApprenticeshipParametersMapper>();
 
-            _mappedParameters = mapper.MapFromRequest(_request);
+            _mappedParameters = mapper.MapFromRequest(_request, VacancyOwnerRelationshipId);
         }
 
         [Test]
@@ -111,6 +113,12 @@ namespace Esfa.Vacancy.UnitTests.CreateApprenticeship.Application.GivenACreateAp
         public void ThenMapsNumberOfPositions()
         {
             _mappedParameters.NumberOfPositions.Should().Be(_request.NumberOfPositions);
+        }
+
+        [Test]
+        public void ThenMapsVacancyOwnerRelationshipId()
+        {
+            _mappedParameters.VacancyOwnerRelationshipId.Should().Be(VacancyOwnerRelationshipId);
         }
     }
 }

--- a/src/Esfa.Vacancy.UnitTests/CreateApprenticeship/Application/GivenACreateApprenticeshipRequestValidator/WhenValidatingEmployerEdsUrn.cs
+++ b/src/Esfa.Vacancy.UnitTests/CreateApprenticeship/Application/GivenACreateApprenticeshipRequestValidator/WhenValidatingEmployerEdsUrn.cs
@@ -11,10 +11,10 @@ namespace Esfa.Vacancy.UnitTests.CreateApprenticeship.Application.GivenACreateAp
     [TestFixture]
     public class WhenValidatingEmployerEdsUrn
     {
-        [TestCase(0, false, TestName = "And is zero Then is invalid")]
-        [TestCase(-1, false, TestName = "And is less than zero Then is invalid")]
-        [TestCase(1, true, TestName = "And is greater than zero Then is valid")]
-        public void AndProviderUkprnIsMissing_ThenIsInvalid(int value, bool shouldBeValid)
+        [TestCase(0, false, "'Employer Eds Urn' should not be empty.", TestName = "And is zero Then is invalid")]
+        [TestCase(-1, false, "'Employer Eds Urn' must be greater than '0'.", TestName = "And is less than zero Then is invalid")]
+        [TestCase(1, true, "", TestName = "And is greater than zero Then is valid")]
+        public void ValidateEmployerEdsUrn(int value, bool shouldBeValid, string errorMessage)
         {
             var request = new CreateApprenticeshipRequest()
             {
@@ -30,7 +30,8 @@ namespace Esfa.Vacancy.UnitTests.CreateApprenticeship.Application.GivenACreateAp
             else
             {
                 var result = validator.ShouldHaveValidationErrorFor(r => r.EmployerEdsUrn, request)
-                    .WithErrorCode(ErrorCodes.CreateApprenticeship.EmployerEdsUrn);
+                    .WithErrorCode(ErrorCodes.CreateApprenticeship.EmployerEdsUrn)
+                    .WithErrorMessage(errorMessage);
                 result.Count().Should().Be(1);
             }
         }

--- a/src/Esfa.Vacancy.UnitTests/CreateApprenticeship/Application/GivenACreateApprenticeshipRequestValidator/WhenValidatingEmployerEdsUrn.cs
+++ b/src/Esfa.Vacancy.UnitTests/CreateApprenticeship/Application/GivenACreateApprenticeshipRequestValidator/WhenValidatingEmployerEdsUrn.cs
@@ -1,0 +1,38 @@
+﻿using System.Linq;
+using Esfa.Vacancy.Application.Commands.CreateApprenticeship;
+using Esfa.Vacancy.Application.Commands.CreateApprenticeship.Validators;
+using Esfa.Vacancy.Domain.Validation;
+using FluentAssertions;
+using FluentValidation.TestHelper;
+using NUnit.Framework;
+
+namespace Esfa.Vacancy.UnitTests.CreateApprenticeship.Application.GivenACreateApprenticeshipRequestValidator
+{
+    [TestFixture]
+    public class WhenValidatingEmployerEdsUrn
+    {
+        [TestCase(0, false, TestName = "And is zero Then is invalid")]
+        [TestCase(-1, false, TestName = "And is less than zero Then is invalid")]
+        [TestCase(1, true, TestName = "And is greater than zero Then is valid")]
+        public void AndProviderUkprnIsMissing_ThenIsInvalid(int value, bool shouldBeValid)
+        {
+            var request = new CreateApprenticeshipRequest()
+            {
+                EmployerEdsUrn = value
+            };
+
+            var validator = new CreateApprenticeshipRequestValidator();
+
+            if (shouldBeValid)
+            {
+                validator.ShouldNotHaveValidationErrorFor(r => r.EmployerEdsUrn, request);
+            }
+            else
+            {
+                var result = validator.ShouldHaveValidationErrorFor(r => r.EmployerEdsUrn, request)
+                    .WithErrorCode(ErrorCodes.CreateApprenticeship.EmployerEdsUrn);
+                result.Count().Should().Be(1);
+            }
+        }
+    }
+}

--- a/src/Esfa.Vacancy.UnitTests/CreateApprenticeship/Application/GivenACreateApprenticeshipRequestValidator/WhenValidatingProviderSiteEdsUrn.cs
+++ b/src/Esfa.Vacancy.UnitTests/CreateApprenticeship/Application/GivenACreateApprenticeshipRequestValidator/WhenValidatingProviderSiteEdsUrn.cs
@@ -1,0 +1,38 @@
+﻿using System.Linq;
+using Esfa.Vacancy.Application.Commands.CreateApprenticeship;
+using Esfa.Vacancy.Application.Commands.CreateApprenticeship.Validators;
+using Esfa.Vacancy.Domain.Validation;
+using FluentAssertions;
+using FluentValidation.TestHelper;
+using NUnit.Framework;
+
+namespace Esfa.Vacancy.UnitTests.CreateApprenticeship.Application.GivenACreateApprenticeshipRequestValidator
+{
+    [TestFixture]
+    public class WhenValidatingProviderSiteEdsUrn
+    {
+        [TestCase(0, false, TestName = "And is zero Then is invalid")]
+        [TestCase(-1, false, TestName = "And is less than zero Then is invalid")]
+        [TestCase(1, true, TestName = "And is greater than zero Then is valid")]
+        public void AndProviderUkprnIsMissing_ThenIsInvalid(int value, bool shouldBeValid)
+        {
+            var request = new CreateApprenticeshipRequest()
+            {
+                ProviderSiteEdsUrn = value
+            };
+
+            var validator = new CreateApprenticeshipRequestValidator();
+
+            if (shouldBeValid)
+            {
+                validator.ShouldNotHaveValidationErrorFor(r => r.ProviderSiteEdsUrn, request);
+            }
+            else
+            {
+                var result = validator.ShouldHaveValidationErrorFor(r => r.ProviderSiteEdsUrn, request)
+                    .WithErrorCode(ErrorCodes.CreateApprenticeship.ProviderSiteEdsUrn);
+                result.Count().Should().Be(1);
+            }
+        }
+    }
+}

--- a/src/Esfa.Vacancy.UnitTests/CreateApprenticeship/Application/GivenACreateApprenticeshipRequestValidator/WhenValidatingProviderSiteEdsUrn.cs
+++ b/src/Esfa.Vacancy.UnitTests/CreateApprenticeship/Application/GivenACreateApprenticeshipRequestValidator/WhenValidatingProviderSiteEdsUrn.cs
@@ -11,10 +11,10 @@ namespace Esfa.Vacancy.UnitTests.CreateApprenticeship.Application.GivenACreateAp
     [TestFixture]
     public class WhenValidatingProviderSiteEdsUrn
     {
-        [TestCase(0, false, TestName = "And is zero Then is invalid")]
-        [TestCase(-1, false, TestName = "And is less than zero Then is invalid")]
-        [TestCase(1, true, TestName = "And is greater than zero Then is valid")]
-        public void AndProviderUkprnIsMissing_ThenIsInvalid(int value, bool shouldBeValid)
+        [TestCase(0, false, "'Provider Site Eds Urn' should not be empty.", TestName = "And is zero Then is invalid")]
+        [TestCase(-1, false, "'Provider Site Eds Urn' must be greater than '0'.", TestName = "And is less than zero Then is invalid")]
+        [TestCase(1, true, "", TestName = "And is greater than zero Then is valid")]
+        public void ValidateProviderSiteEdsUrn(int value, bool shouldBeValid, string errorMessage)
         {
             var request = new CreateApprenticeshipRequest()
             {
@@ -30,7 +30,8 @@ namespace Esfa.Vacancy.UnitTests.CreateApprenticeship.Application.GivenACreateAp
             else
             {
                 var result = validator.ShouldHaveValidationErrorFor(r => r.ProviderSiteEdsUrn, request)
-                    .WithErrorCode(ErrorCodes.CreateApprenticeship.ProviderSiteEdsUrn);
+                    .WithErrorCode(ErrorCodes.CreateApprenticeship.ProviderSiteEdsUrn)
+                    .WithErrorMessage(errorMessage);
                 result.Count().Should().Be(1);
             }
         }

--- a/src/Esfa.Vacancy.UnitTests/CreateApprenticeship/Application/GivenACreateApprenticeshipRequestValidator/WhenValidatingProviderUkprn.cs
+++ b/src/Esfa.Vacancy.UnitTests/CreateApprenticeship/Application/GivenACreateApprenticeshipRequestValidator/WhenValidatingProviderUkprn.cs
@@ -1,0 +1,38 @@
+﻿using System.Linq;
+using Esfa.Vacancy.Application.Commands.CreateApprenticeship;
+using Esfa.Vacancy.Application.Commands.CreateApprenticeship.Validators;
+using Esfa.Vacancy.Domain.Validation;
+using FluentAssertions;
+using FluentValidation.TestHelper;
+using NUnit.Framework;
+
+namespace Esfa.Vacancy.UnitTests.CreateApprenticeship.Application.GivenACreateApprenticeshipRequestValidator
+{
+    [TestFixture]
+    public class WhenValidatingProviderUkprn
+    {
+        [TestCase(0, false, TestName = "And is zero Then is invalid")]
+        [TestCase(-1, false, TestName = "And is less than zero Then is invalid")]
+        [TestCase(1, true, TestName = "And is greater than zero Then is valid")]
+        public void AndProviderUkprnIsMissing_ThenIsInvalid(int value, bool shouldBeValid)
+        {
+            var request = new CreateApprenticeshipRequest()
+            {
+                ProviderUkprn = value
+            };
+
+            var validator = new CreateApprenticeshipRequestValidator();
+
+            if (shouldBeValid)
+            {
+                validator.ShouldNotHaveValidationErrorFor(r => r.ProviderUkprn, request);
+            }
+            else
+            {
+                var result = validator.ShouldHaveValidationErrorFor(r => r.ProviderUkprn, request)
+                    .WithErrorCode(ErrorCodes.CreateApprenticeship.ProviderUkprn);
+                result.Count().Should().Be(1);
+            }
+        }
+    }
+}

--- a/src/Esfa.Vacancy.UnitTests/CreateApprenticeship/Application/GivenACreateApprenticeshipRequestValidator/WhenValidatingProviderUkprn.cs
+++ b/src/Esfa.Vacancy.UnitTests/CreateApprenticeship/Application/GivenACreateApprenticeshipRequestValidator/WhenValidatingProviderUkprn.cs
@@ -11,10 +11,10 @@ namespace Esfa.Vacancy.UnitTests.CreateApprenticeship.Application.GivenACreateAp
     [TestFixture]
     public class WhenValidatingProviderUkprn
     {
-        [TestCase(0, false, TestName = "And is zero Then is invalid")]
-        [TestCase(-1, false, TestName = "And is less than zero Then is invalid")]
-        [TestCase(1, true, TestName = "And is greater than zero Then is valid")]
-        public void AndProviderUkprnIsMissing_ThenIsInvalid(int value, bool shouldBeValid)
+        [TestCase(0, false, "'Provider Ukprn' should not be empty.", TestName = "And is zero Then is invalid")]
+        [TestCase(-1, false, "'Provider Ukprn' must be greater than '0'.", TestName = "And is less than zero Then is invalid")]
+        [TestCase(1, true, "", TestName = "And is greater than zero Then is valid")]
+        public void ValidateProviderUkprn(int value, bool shouldBeValid, string errorMessage)
         {
             var request = new CreateApprenticeshipRequest()
             {
@@ -30,7 +30,8 @@ namespace Esfa.Vacancy.UnitTests.CreateApprenticeship.Application.GivenACreateAp
             else
             {
                 var result = validator.ShouldHaveValidationErrorFor(r => r.ProviderUkprn, request)
-                    .WithErrorCode(ErrorCodes.CreateApprenticeship.ProviderUkprn);
+                    .WithErrorCode(ErrorCodes.CreateApprenticeship.ProviderUkprn)
+                    .WithErrorMessage(errorMessage);
                 result.Count().Should().Be(1);
             }
         }

--- a/src/Esfa.Vacancy.UnitTests/Esfa.Vacancy.UnitTests.csproj
+++ b/src/Esfa.Vacancy.UnitTests/Esfa.Vacancy.UnitTests.csproj
@@ -161,6 +161,7 @@
     <Compile Include="SearchApprenticeship\Domain\GivenAVacancySearchParameters\WhenCallingToString.cs" />
     <Compile Include="SearchApprenticeship\Infrastructure\GivenAGeoSearchResultDistanceSetter.cs" />
     <Compile Include="Shared\Api.Core\GivenHttpRequestExtensions.cs" />
+    <Compile Include="Shared\Api.Core\GivenProviderAuthorizationFilter.cs" />
     <Compile Include="Shared\Api\Validation\GivenAValidationExceptionBuilder.cs" />
     <Compile Include="Shared\Infrastructure\GivenACachedFrameworkCodeRepository\WhenCallingGetAsync.cs" />
     <Compile Include="Shared\Infrastructure\GivenACachedStandardRepository\WhenCallingGetStandardIdsAsync.cs" />

--- a/src/Esfa.Vacancy.UnitTests/Esfa.Vacancy.UnitTests.csproj
+++ b/src/Esfa.Vacancy.UnitTests/Esfa.Vacancy.UnitTests.csproj
@@ -129,9 +129,12 @@
     <Compile Include="CreateApprenticeship\Application\GivenACreateApprenticeshipRequestValidator\AndLocationTypeOfOther\WhenValidatingTown.cs" />
     <Compile Include="CreateApprenticeship\Application\GivenACreateApprenticeshipRequestValidator\CreateApprenticeshipRequestValidatorBase.cs" />
     <Compile Include="CreateApprenticeship\Application\GivenACreateApprenticeshipRequestValidator\WhenValidatingApplicationClosingDate.cs" />
+    <Compile Include="CreateApprenticeship\Application\GivenACreateApprenticeshipRequestValidator\WhenValidatingEmployerEdsUrn.cs" />
     <Compile Include="CreateApprenticeship\Application\GivenACreateApprenticeshipRequestValidator\WhenValidatingExpectedStartDate.cs" />
     <Compile Include="CreateApprenticeship\Application\GivenACreateApprenticeshipRequestValidator\WhenValidatingHoursPerWeek.cs" />
+    <Compile Include="CreateApprenticeship\Application\GivenACreateApprenticeshipRequestValidator\WhenValidatingProviderUkprn.cs" />
     <Compile Include="CreateApprenticeship\Application\GivenACreateApprenticeshipRequestValidator\WhenValidatingNumberOfPositions.cs" />
+    <Compile Include="CreateApprenticeship\Application\GivenACreateApprenticeshipRequestValidator\WhenValidatingProviderSiteEdsUrn.cs" />
     <Compile Include="CreateApprenticeship\Application\GivenACreateApprenticeshipRequestValidator\WhenValidatingWorkingWeek.cs" />
     <Compile Include="CreateApprenticeship\Application\GivenACreateApprenticeshipRequestValidator\WhenValidatingLocationType.cs" />
     <Compile Include="CreateApprenticeship\Application\GivenACreateApprenticeshipRequestValidator\WhenValidatingLongDescription.cs" />

--- a/src/Esfa.Vacancy.UnitTests/Esfa.Vacancy.UnitTests.csproj
+++ b/src/Esfa.Vacancy.UnitTests/Esfa.Vacancy.UnitTests.csproj
@@ -160,6 +160,7 @@
     <Compile Include="SearchApprenticeship\Domain\GivenAVacancySearchParameters\WhenCallingHasGeoSearchFields.cs" />
     <Compile Include="SearchApprenticeship\Domain\GivenAVacancySearchParameters\WhenCallingToString.cs" />
     <Compile Include="SearchApprenticeship\Infrastructure\GivenAGeoSearchResultDistanceSetter.cs" />
+    <Compile Include="Shared\Api.Core\GivenHttpRequestExtensions.cs" />
     <Compile Include="Shared\Api\Validation\GivenAValidationExceptionBuilder.cs" />
     <Compile Include="Shared\Infrastructure\GivenACachedFrameworkCodeRepository\WhenCallingGetAsync.cs" />
     <Compile Include="Shared\Infrastructure\GivenACachedStandardRepository\WhenCallingGetStandardIdsAsync.cs" />

--- a/src/Esfa.Vacancy.UnitTests/Shared/Api.Core/GivenHttpRequestExtensions.cs
+++ b/src/Esfa.Vacancy.UnitTests/Shared/Api.Core/GivenHttpRequestExtensions.cs
@@ -22,5 +22,15 @@ namespace Esfa.Vacancy.UnitTests.Shared.Api.Core
 
             result.ContainsKey(key).Should().Be(included);
         }
+
+        [TestCase("TestHeader1", "Value", TestName = "And Header exists then return value of the header")]
+        [TestCase("TestHeader2", null, TestName = "And Header doesn't exists then return null")]
+        public void WhenGetHeaderValue(string key, string value)
+        {
+            var request = new HttpRequestMessage();
+            request.Headers.Add("TestHeader1", "Value");
+
+            request.GetHeaderValue(key).Should().Be(value);
+        }
     }
 }

--- a/src/Esfa.Vacancy.UnitTests/Shared/Api.Core/GivenHttpRequestExtensions.cs
+++ b/src/Esfa.Vacancy.UnitTests/Shared/Api.Core/GivenHttpRequestExtensions.cs
@@ -1,0 +1,26 @@
+﻿using System.Net.Http;
+using Esfa.Vacancy.Api.Core.Extensions;
+using FluentAssertions;
+using NUnit.Framework;
+using NUnit.Framework.Internal;
+
+namespace Esfa.Vacancy.UnitTests.Shared.Api.Core
+{
+    [TestFixture]
+    public class GivenHttpRequestExtensions
+    {
+        [TestCase("x-request-context-user-id", "JohnSerco", true, TestName = "And the key is valid then it is included")]
+        [TestCase("user-email", "JohnSerco@hotmail.com", false, TestName = "And the key is unknown then it is not included")]
+        [TestCase("x-request-context-user-note", null, true, TestName = "And the header value is null then it is included")]
+        public void WhenGetApimUserContextHeaders(string key, string value, bool included)
+        {
+            var request = new HttpRequestMessage();
+
+            request.Headers.Add(key, value);
+
+            var result = request.GetApimUserContextHeaders();
+
+            result.ContainsKey(key).Should().Be(included);
+        }
+    }
+}

--- a/src/Esfa.Vacancy.UnitTests/Shared/Api.Core/GivenProviderAuthorizationFilter.cs
+++ b/src/Esfa.Vacancy.UnitTests/Shared/Api.Core/GivenProviderAuthorizationFilter.cs
@@ -1,0 +1,55 @@
+﻿using System;
+using System.Net.Http;
+using System.Web.Http.Controllers;
+using Esfa.Vacancy.Api.Core;
+using Esfa.Vacancy.Api.Core.ActionFilters;
+using Esfa.Vacancy.Api.Core.Extensions;
+using Esfa.Vacancy.Application.Exceptions;
+using FluentAssertions;
+using NUnit.Framework;
+
+namespace Esfa.Vacancy.UnitTests.Shared.Api.Core
+{
+    [TestFixture]
+    public class GivenProviderAuthorizationFilter
+    {
+        [TestCase("somevalue", TestName = "And is unexpected value then throw unauthorised exception")]
+        [TestCase(null, TestName = "And is missing then throw unauthorised exception")]
+        public void WhenInvalidHeader(string value)
+        {
+            Action action = () =>
+            {
+                var context = new HttpActionContext();
+
+                var request = new HttpRequestMessage();
+                request.Headers.Add(Constants.RequestHeaderNames.UserNote, value);
+
+                context.ControllerContext = new HttpControllerContext { Request = request };
+                var filter = new ProviderAuthorisationFilter();
+                filter.OnActionExecuting(context);
+            };
+
+            action.ShouldThrow<UnauthorisedException>().WithMessage(Constants.AuthorisationErrorMessages.InvalidUkprn);
+        }
+
+        [TestCase("ukprn=12345678", TestName = "Then lower case is allowed")]
+        [TestCase("UKPRN=12345678", TestName = "Then upper case is allowed")]
+        [TestCase("UKpRN=12345678", TestName = "Then mixed case is allowed")]
+        [TestCase("UKpRN = 12345678", TestName = "Then spaces are allowed")]
+        public void WhenValidHeader(string value)
+        {
+            var context = new HttpActionContext();
+
+            var request = new HttpRequestMessage();
+            request.Headers.Add(Constants.RequestHeaderNames.UserNote, value);
+
+            context.ControllerContext = new HttpControllerContext { Request = request };
+            var filter = new ProviderAuthorisationFilter();
+            filter.OnActionExecuting(context);
+
+            context.Request.GetHeaderValue(Constants.RequestHeaderNames.ProviderUkprn).Should().Be("12345678");
+
+            Assert.IsNull(context.Response);
+        }
+    }
+}

--- a/src/Esfa.Vacancy.UnitTests/Shared/Api.Core/GivenProviderAuthorizationFilter.cs
+++ b/src/Esfa.Vacancy.UnitTests/Shared/Api.Core/GivenProviderAuthorizationFilter.cs
@@ -38,6 +38,7 @@ namespace Esfa.Vacancy.UnitTests.Shared.Api.Core
         [TestCase("UKpRN = 12345678", TestName = "Then spaces are allowed")]
         public void WhenValidHeader(string value)
         {
+            const string expectedValue = "12345678";
             var context = new HttpActionContext();
 
             var request = new HttpRequestMessage();
@@ -47,7 +48,7 @@ namespace Esfa.Vacancy.UnitTests.Shared.Api.Core
             var filter = new ProviderAuthorisationFilter();
             filter.OnActionExecuting(context);
 
-            context.Request.GetHeaderValue(Constants.RequestHeaderNames.ProviderUkprn).Should().Be("12345678");
+            context.Request.GetHeaderValue(Constants.RequestHeaderNames.ProviderUkprn).Should().Be(expectedValue);
 
             Assert.IsNull(context.Response);
         }


### PR DESCRIPTION
Originally I was going to wait till I finish the third story RA-1549 which is to do with EmploerLocation type, however since there are few fundamental refactorings required to carry so I thought I will get this out first. Also this PR has already touched 36 files, if I continue it could get close to three figures. 

I have created a custom filter to authorise user request based on UKPRN. This will stop the request if correctly formatted ukprn text is not recovered from the header. The actual validation takes place further down the line in the command handler, which if failed raises unauthorise exception as well. 

I am using only single error code for fields introduced with this PR, which is one of the refactoring required for fields that have already made in with multiple error codes. 

Also introduced `SqlDatabaseService` class that acts like a buddy class to establish sql connection and  also apply retry policy. This will be applied retrospectively to other repositories. 

