### PR TITLE
Feature/RA-1514 NationalMinWage and Custom wage types

### DIFF
--- a/src/Esfa.Vacancy.Api.Types/WageType.cs
+++ b/src/Esfa.Vacancy.Api.Types/WageType.cs
@@ -2,6 +2,8 @@
 {
     public enum WageType
     {
-        ApprenticeshipMinimumWage = 2
+        Custom = 1,
+        NationalMinimumWage = 2,
+        ApprenticeshipMinimumWage = 3
     }
 }

--- a/src/Esfa.Vacancy.Api.Types/WageType.cs
+++ b/src/Esfa.Vacancy.Api.Types/WageType.cs
@@ -4,6 +4,9 @@
     {
         Custom = 1,
         NationalMinimumWage = 2,
-        ApprenticeshipMinimumWage = 3
+        ApprenticeshipMinimumWage = 3,
+        Unwaged = 4,
+        CompetitiveSalary = 5,
+        ToBeSpecified = 6
     }
 }

--- a/src/Esfa.Vacancy.Application/Commands/CreateApprenticeship/CreateApprenticeshipParametersMapper.cs
+++ b/src/Esfa.Vacancy.Application/Commands/CreateApprenticeship/CreateApprenticeshipParametersMapper.cs
@@ -4,7 +4,14 @@ namespace Esfa.Vacancy.Application.Commands.CreateApprenticeship
 {
     public class CreateApprenticeshipParametersMapper : ICreateApprenticeshipParametersMapper
     {
+        private readonly IWageTypeMapper _wageTypeMapper;
         private const int StandardLocationType = 1;
+
+        public CreateApprenticeshipParametersMapper(IWageTypeMapper wageTypeMapper)
+        {
+            _wageTypeMapper = wageTypeMapper;
+        }
+        
         public CreateApprenticeshipParameters MapFromRequest(CreateApprenticeshipRequest request,
             EmployerInformation employerInformation)
         {
@@ -17,7 +24,7 @@ namespace Esfa.Vacancy.Application.Commands.CreateApprenticeship
                 ExpectedStartDate = request.ExpectedStartDate,
                 WorkingWeek = request.WorkingWeek,
                 HoursPerWeek = request.HoursPerWeek,
-                WageType = (Domain.Entities.LegacyWageType)request.WageType,
+                WageType = _wageTypeMapper.MapToLegacy(request.WageType),
                 LocationTypeId = StandardLocationType, //This should change when more location type are introduced
                 AddressLine1 = request.AddressLine1,
                 AddressLine2 = request.AddressLine2,

--- a/src/Esfa.Vacancy.Application/Commands/CreateApprenticeship/IWageTypeMapper.cs
+++ b/src/Esfa.Vacancy.Application/Commands/CreateApprenticeship/IWageTypeMapper.cs
@@ -1,0 +1,9 @@
+﻿using Esfa.Vacancy.Domain.Entities;
+
+namespace Esfa.Vacancy.Application.Commands.CreateApprenticeship
+{
+    public interface IWageTypeMapper
+    {
+        LegacyWageType MapToLegacy(WageType originalWageType);
+    }
+}

--- a/src/Esfa.Vacancy.Application/Commands/CreateApprenticeship/Validators/WageTypeValidator.cs
+++ b/src/Esfa.Vacancy.Application/Commands/CreateApprenticeship/Validators/WageTypeValidator.cs
@@ -24,6 +24,17 @@ namespace Esfa.Vacancy.Application.Commands.CreateApprenticeship.Validators
                     .Null()
                     .WithErrorCode(ErrorCodes.CreateApprenticeship.MaxWage);
             });
+
+            When(request => request.WageType == WageType.NationalMinimumWage, () =>
+            {
+                RuleFor(request => request.MinWage)
+                    .Null()
+                    .WithErrorCode(ErrorCodes.CreateApprenticeship.MinWage);
+
+                RuleFor(request => request.MaxWage)
+                    .Null()
+                    .WithErrorCode(ErrorCodes.CreateApprenticeship.MaxWage);
+            });
         }
     }
 }

--- a/src/Esfa.Vacancy.Application/Commands/CreateApprenticeship/WageTypeMapper.cs
+++ b/src/Esfa.Vacancy.Application/Commands/CreateApprenticeship/WageTypeMapper.cs
@@ -1,0 +1,29 @@
+﻿using System;
+using Esfa.Vacancy.Domain.Entities;
+
+namespace Esfa.Vacancy.Application.Commands.CreateApprenticeship
+{
+    public class WageTypeMapper : IWageTypeMapper
+    {
+        public LegacyWageType MapToLegacy(WageType originalWageType)
+        {
+            switch (originalWageType)
+            {
+                case WageType.Custom:
+                    return LegacyWageType.Custom;
+                case WageType.NationalMinimumWage:
+                    return LegacyWageType.NationalMinimum;
+                case WageType.ApprenticeshipMinimumWage:
+                    return LegacyWageType.ApprenticeshipMinimum;
+                case WageType.Unwaged:
+                    return LegacyWageType.Unwaged;
+                case WageType.CompetitiveSalary:
+                    return LegacyWageType.CompetitiveSalary;
+                case WageType.ToBeSpecified:
+                    return LegacyWageType.ToBeAgreedUponAppointment;
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(originalWageType), originalWageType, null);
+            }
+        }
+    }
+}

--- a/src/Esfa.Vacancy.Application/Esfa.Vacancy.Application.csproj
+++ b/src/Esfa.Vacancy.Application/Esfa.Vacancy.Application.csproj
@@ -70,6 +70,7 @@
     <Compile Include="Commands\CreateApprenticeship\CreateApprenticeshipCommandHandler.cs" />
     <Compile Include="Commands\CreateApprenticeship\CreateApprenticeshipParametersMapper.cs" />
     <Compile Include="Commands\CreateApprenticeship\CreateApprenticeshipRequest.cs" />
+    <Compile Include="Commands\CreateApprenticeship\IWageTypeMapper.cs" />
     <Compile Include="Commands\CreateApprenticeship\Validators\CreateApprenticeshipRequestValidator.cs" />
     <Compile Include="Commands\CreateApprenticeship\CreateApprenticeshipResponse.cs" />
     <Compile Include="Commands\CreateApprenticeship\ICreateApprenticeshipParametersMapper.cs" />
@@ -88,6 +89,7 @@
     <Compile Include="Commands\CreateApprenticeship\Validators\WageTypeValidator.cs" />
     <Compile Include="Commands\CreateApprenticeship\Validators\WorkingWeekValidator.cs" />
     <Compile Include="Commands\CreateApprenticeship\WageType.cs" />
+    <Compile Include="Commands\CreateApprenticeship\WageTypeMapper.cs" />
     <Compile Include="Exceptions\UnauthorisedException.cs" />
     <Compile Include="Exceptions\ResourceNotFoundException.cs" />
     <Compile Include="Interfaces\ITrainingDetailService.cs" />

--- a/src/Esfa.Vacancy.UnitTests/CreateApprenticeship/Application/GivenACreateApprenticeshipRequestValidator/AndWageTypeNationalMinimumWage/WhenValidatingMaxWage.cs
+++ b/src/Esfa.Vacancy.UnitTests/CreateApprenticeship/Application/GivenACreateApprenticeshipRequestValidator/AndWageTypeNationalMinimumWage/WhenValidatingMaxWage.cs
@@ -1,0 +1,56 @@
+﻿using System.Linq;
+using System.Threading.Tasks;
+using Esfa.Vacancy.Application.Commands.CreateApprenticeship;
+using Esfa.Vacancy.Application.Commands.CreateApprenticeship.Validators;
+using Esfa.Vacancy.Domain.Validation;
+using FluentAssertions;
+using NUnit.Framework;
+using Ploeh.AutoFixture;
+
+namespace Esfa.Vacancy.UnitTests.CreateApprenticeship.Application.GivenACreateApprenticeshipRequestValidator.AndWageTypeNationalMinimumWage
+{
+    [TestFixture]
+    public class WhenValidatingMaxWage : CreateApprenticeshipRequestValidatorBase
+    {
+        [Test]
+        public async Task AndHasValueThenIsInvalid()
+        {
+            var fixture = new Fixture();
+            var request = new CreateApprenticeshipRequest
+            {
+                WageType = WageType.NationalMinimumWage,
+                MaxWage = fixture.Create<decimal>()
+            };
+
+            var context = GetValidationContextForProperty(request, req => req.MaxWage);
+
+            var validator = fixture.Create<CreateApprenticeshipRequestValidator>();
+
+            var result = await validator.ValidateAsync(context);
+
+            result.IsValid.Should().Be(false);
+            result.Errors.First().ErrorCode
+                .Should().Be(ErrorCodes.CreateApprenticeship.MaxWage);
+            result.Errors.First().ErrorMessage
+                .Should().Be("'Max Wage' must be empty.");
+        }
+
+        [Test]
+        public async Task AndNoValueThenIsValid()
+        {
+            var fixture = new Fixture();
+            var request = new CreateApprenticeshipRequest
+            {
+                WageType = WageType.NationalMinimumWage
+            };
+
+            var context = GetValidationContextForProperty(request, req => req.MaxWage);
+
+            var validator = fixture.Create<CreateApprenticeshipRequestValidator>();
+
+            var result = await validator.ValidateAsync(context);
+
+            result.IsValid.Should().Be(true);
+        }
+    }
+}

--- a/src/Esfa.Vacancy.UnitTests/CreateApprenticeship/Application/GivenACreateApprenticeshipRequestValidator/AndWageTypeNationalMinimumWage/WhenValidatingMinWage.cs
+++ b/src/Esfa.Vacancy.UnitTests/CreateApprenticeship/Application/GivenACreateApprenticeshipRequestValidator/AndWageTypeNationalMinimumWage/WhenValidatingMinWage.cs
@@ -1,0 +1,56 @@
+﻿using System.Linq;
+using System.Threading.Tasks;
+using Esfa.Vacancy.Application.Commands.CreateApprenticeship;
+using Esfa.Vacancy.Application.Commands.CreateApprenticeship.Validators;
+using Esfa.Vacancy.Domain.Validation;
+using FluentAssertions;
+using NUnit.Framework;
+using Ploeh.AutoFixture;
+
+namespace Esfa.Vacancy.UnitTests.CreateApprenticeship.Application.GivenACreateApprenticeshipRequestValidator.AndWageTypeNationalMinimumWage
+{
+    [TestFixture]
+    public class WhenValidatingMinWage : CreateApprenticeshipRequestValidatorBase
+    {
+        [Test]
+        public async Task AndHasValueThenIsInvalid()
+        {
+            var fixture = new Fixture();
+            var request = new CreateApprenticeshipRequest
+            {
+                WageType = WageType.NationalMinimumWage,
+                MinWage = fixture.Create<decimal>()
+            };
+
+            var context = GetValidationContextForProperty(request, req => req.MinWage);
+
+            var validator = fixture.Create<CreateApprenticeshipRequestValidator>();
+
+            var result = await validator.ValidateAsync(context);
+
+            result.IsValid.Should().Be(false);
+            result.Errors.First().ErrorCode
+                .Should().Be(ErrorCodes.CreateApprenticeship.MinWage);
+            result.Errors.First().ErrorMessage
+                .Should().Be("'Min Wage' must be empty.");
+        }
+
+        [Test]
+        public async Task AndNoValueThenIsValid()
+        {
+            var fixture = new Fixture();
+            var request = new CreateApprenticeshipRequest
+            {
+                WageType = WageType.NationalMinimumWage
+            };
+
+            var context = GetValidationContextForProperty(request, req => req.MinWage);
+
+            var validator = fixture.Create<CreateApprenticeshipRequestValidator>();
+
+            var result = await validator.ValidateAsync(context);
+
+            result.IsValid.Should().Be(true);
+        }
+    }
+}

--- a/src/Esfa.Vacancy.UnitTests/CreateApprenticeship/Application/GivenAWageTypeMapper/WhenMappingWageType.cs
+++ b/src/Esfa.Vacancy.UnitTests/CreateApprenticeship/Application/GivenAWageTypeMapper/WhenMappingWageType.cs
@@ -1,0 +1,34 @@
+﻿using System;
+using Esfa.Vacancy.Application.Commands.CreateApprenticeship;
+using Esfa.Vacancy.Domain.Entities;
+using FluentAssertions;
+using NUnit.Framework;
+using WageType = Esfa.Vacancy.Application.Commands.CreateApprenticeship.WageType;
+
+namespace Esfa.Vacancy.UnitTests.CreateApprenticeship.Application.GivenAWageTypeMapper
+{
+    [TestFixture]
+    public class WhenMappingWageType
+    {
+        [TestCase(WageType.Custom, LegacyWageType.Custom, TestName = "Custom")]
+        [TestCase(WageType.NationalMinimumWage, LegacyWageType.NationalMinimum, TestName = "NationalMinimumWage")]
+        [TestCase(WageType.ApprenticeshipMinimumWage, LegacyWageType.ApprenticeshipMinimum, TestName = "ApprenticeshipMinimumWage")]
+        [TestCase(WageType.Unwaged, LegacyWageType.Unwaged, TestName = "Unwaged")]
+        [TestCase(WageType.CompetitiveSalary, LegacyWageType.CompetitiveSalary, TestName = "CompetitiveSalary")]
+        [TestCase(WageType.ToBeSpecified, LegacyWageType.ToBeAgreedUponAppointment, TestName = "ToBeSpecified")]
+        public void ThenMapsToLegacyWageType(WageType originalWageType, LegacyWageType expectedLegacyWageType)
+        {
+            var wageTypeMapper = new WageTypeMapper();
+            wageTypeMapper.MapToLegacy(originalWageType)
+                .Should().Be(expectedLegacyWageType);
+        }
+
+        [Test]
+        public void AndOutOfRange_ThenThrowsException()
+        {
+            var wageTypeMapper = new WageTypeMapper();
+            Action action = () => wageTypeMapper.MapToLegacy((WageType)8435);
+            action.ShouldThrow<ArgumentOutOfRangeException>();
+        }
+    }
+}

--- a/src/Esfa.Vacancy.UnitTests/Esfa.Vacancy.UnitTests.csproj
+++ b/src/Esfa.Vacancy.UnitTests/Esfa.Vacancy.UnitTests.csproj
@@ -129,6 +129,8 @@
     <Compile Include="CreateApprenticeship\Application\GivenACreateApprenticeshipRequestValidator\AndLocationTypeOfOther\WhenValidatingTown.cs" />
     <Compile Include="CreateApprenticeship\Application\GivenACreateApprenticeshipRequestValidator\AndWageTypeApprenticeshipMinimumWage\WhenValidatingMaxWage.cs" />
     <Compile Include="CreateApprenticeship\Application\GivenACreateApprenticeshipRequestValidator\AndWageTypeApprenticeshipMinimumWage\WhenValidatingMinWage.cs" />
+    <Compile Include="CreateApprenticeship\Application\GivenACreateApprenticeshipRequestValidator\AndWageTypeNationalMinimumWage\WhenValidatingMaxWage.cs" />
+    <Compile Include="CreateApprenticeship\Application\GivenACreateApprenticeshipRequestValidator\AndWageTypeNationalMinimumWage\WhenValidatingMinWage.cs" />
     <Compile Include="CreateApprenticeship\Application\GivenACreateApprenticeshipRequestValidator\CreateApprenticeshipRequestValidatorBase.cs" />
     <Compile Include="CreateApprenticeship\Application\GivenACreateApprenticeshipRequestValidator\WhenValidatingApplicationClosingDate.cs" />
     <Compile Include="CreateApprenticeship\Application\GivenACreateApprenticeshipRequestValidator\WhenValidatingEmployerEdsUrn.cs" />

--- a/src/Esfa.Vacancy.UnitTests/Esfa.Vacancy.UnitTests.csproj
+++ b/src/Esfa.Vacancy.UnitTests/Esfa.Vacancy.UnitTests.csproj
@@ -145,6 +145,7 @@
     <Compile Include="CreateApprenticeship\Application\GivenACreateApprenticeshipRequestValidator\WhenValidatingTitle.cs" />
     <Compile Include="CreateApprenticeship\Application\GivenACreateApprenticeshipRequestValidator\WhenValidatingWithMatchesAllowedHtmlFreeTextCharacters.cs" />
     <Compile Include="CreateApprenticeship\Application\GivenACreateApprenticeshipRequestValidator\WhenValidatingWithMatchesAllowedFreeTextCharacters.cs" />
+    <Compile Include="CreateApprenticeship\Application\GivenAWageTypeMapper\WhenMappingWageType.cs" />
     <Compile Include="GetApprenticeshipVacancy\Api\Mappings\GivenAnApprenticeshipMapper\WhenMappingIsNationwide.cs" />
     <Compile Include="SearchApprenticeship\Api\Mappings\GivenASearchApprenticeshipParametersMapper\WhenMappingDistanceInMiles.cs" />
     <Compile Include="SearchApprenticeship\Api\Mappings\GivenASearchApprenticeshipParametersMapper\WhenMappingLongitude.cs" />


### PR DESCRIPTION
This story is really just enabling the validation for NationalMinimumWage. Custom wage type validation is dealt with in subsequent stories.
The branch also includes specific mapping for wage type to the legacy wage types which was previously allowing mapping to disused legacy wage types.