### PR TITLE
Feature/RA-1417 wage type reason

### DIFF
--- a/src/Esfa.Vacancy.Api.Types/CreateApprenticeshipParameters.cs
+++ b/src/Esfa.Vacancy.Api.Types/CreateApprenticeshipParameters.cs
@@ -45,7 +45,7 @@ namespace Esfa.Vacancy.Api.Types
         public WageType WageType { get; set; }
 
         /// <summary>
-        /// The reason for choosing the wage type
+        /// The reason for choosing the wage type of 'CompetitiveSalary', 'Unwaged' or 'ToBeSpecified'.
         /// </summary>
         public string WageTypeReason { get; set; }
 

--- a/src/Esfa.Vacancy.Api.Types/CreateApprenticeshipParameters.cs
+++ b/src/Esfa.Vacancy.Api.Types/CreateApprenticeshipParameters.cs
@@ -45,6 +45,11 @@ namespace Esfa.Vacancy.Api.Types
         public WageType WageType { get; set; }
 
         /// <summary>
+        /// The reason for choosing the wage type
+        /// </summary>
+        public string WageTypeReason { get; set; }
+
+        /// <summary>
         /// The minimum wage for the vacancy
         /// </summary>
         public decimal? MinWage { get; set; }

--- a/src/Esfa.Vacancy.Application/Commands/CreateApprenticeship/CreateApprenticeshipParametersMapper.cs
+++ b/src/Esfa.Vacancy.Application/Commands/CreateApprenticeship/CreateApprenticeshipParametersMapper.cs
@@ -25,6 +25,7 @@ namespace Esfa.Vacancy.Application.Commands.CreateApprenticeship
                 WorkingWeek = request.WorkingWeek,
                 HoursPerWeek = request.HoursPerWeek,
                 WageType = _wageTypeMapper.MapToLegacy(request.WageType),
+                WageTypeReason = request.WageTypeReason,
                 LocationTypeId = request.LocationType == LocationType.Nationwide ? NationwideLocationType : StandardLocationType,
                 NumberOfPositions = request.NumberOfPositions,
                 VacancyOwnerRelationshipId = employerInformation.VacancyOwnerRelationshipId.Value, //a value should always exist

--- a/src/Esfa.Vacancy.Application/Commands/CreateApprenticeship/CreateApprenticeshipRequest.cs
+++ b/src/Esfa.Vacancy.Application/Commands/CreateApprenticeship/CreateApprenticeshipRequest.cs
@@ -13,6 +13,7 @@ namespace Esfa.Vacancy.Application.Commands.CreateApprenticeship
         public string WorkingWeek { get; set; }
         public double HoursPerWeek { get; set; }
         public WageType WageType { get; set; }
+        public string WageTypeReason { get; set; }
         public decimal? MinWage { get; set; }
         public decimal? MaxWage { get; set; }
         public LocationType LocationType { get; set; }

--- a/src/Esfa.Vacancy.Application/Commands/CreateApprenticeship/Validators/WageTypeValidator.cs
+++ b/src/Esfa.Vacancy.Application/Commands/CreateApprenticeship/Validators/WageTypeValidator.cs
@@ -14,7 +14,22 @@ namespace Esfa.Vacancy.Application.Commands.CreateApprenticeship.Validators
                     .IsInEnum()
                     .WithErrorCode(ErrorCodes.CreateApprenticeship.WageType));
 
-            When(request => request.WageType == WageType.ApprenticeshipMinimumWage, () =>
+            When(request => request.WageType == WageType.Custom, () =>
+            {
+                RuleFor(request => request.MinWage)
+                    .NotNull()
+                    .WithErrorCode(ErrorCodes.CreateApprenticeship.MinWage);
+
+                RuleFor(request => request.MaxWage)
+                    .NotNull()
+                    .WithErrorCode(ErrorCodes.CreateApprenticeship.MaxWage);
+
+                RuleFor(request => request.WageTypeReason)
+                    .Null()
+                    .WithErrorCode(ErrorCodes.CreateApprenticeship.WageTypeReason);
+            });
+
+            When(request => request.WageType == WageType.NationalMinimumWage, () =>
             {
                 RuleFor(request => request.MinWage)
                     .Null()
@@ -29,7 +44,7 @@ namespace Esfa.Vacancy.Application.Commands.CreateApprenticeship.Validators
                     .WithErrorCode(ErrorCodes.CreateApprenticeship.WageTypeReason);
             });
 
-            When(request => request.WageType == WageType.NationalMinimumWage, () =>
+            When(request => request.WageType == WageType.ApprenticeshipMinimumWage, () =>
             {
                 RuleFor(request => request.MinWage)
                     .Null()

--- a/src/Esfa.Vacancy.Application/Commands/CreateApprenticeship/Validators/WageTypeValidator.cs
+++ b/src/Esfa.Vacancy.Application/Commands/CreateApprenticeship/Validators/WageTypeValidator.cs
@@ -14,12 +14,6 @@ namespace Esfa.Vacancy.Application.Commands.CreateApprenticeship.Validators
                     .IsInEnum()
                     .WithErrorCode(ErrorCodes.CreateApprenticeship.WageType));
 
-            RuleFor(request => request.WageTypeReason)
-                .MaximumLength(240)
-                .WithErrorCode(ErrorCodes.CreateApprenticeship.WageTypeReason)
-                .MatchesAllowedFreeTextCharacters()
-                .WithErrorCode(ErrorCodes.CreateApprenticeship.WageTypeReason);
-
             When(request => request.WageType == WageType.Custom, () =>
             {
                 RuleFor(request => request.MinWage)
@@ -109,6 +103,12 @@ namespace Esfa.Vacancy.Application.Commands.CreateApprenticeship.Validators
                     .NotNull()
                     .WithErrorCode(ErrorCodes.CreateApprenticeship.WageTypeReason);
             });
+
+            RuleFor(request => request.WageTypeReason)
+                .MaximumLength(240)
+                .WithErrorCode(ErrorCodes.CreateApprenticeship.WageTypeReason)
+                .MatchesAllowedFreeTextCharacters()
+                .WithErrorCode(ErrorCodes.CreateApprenticeship.WageTypeReason);
         }
     }
 }

--- a/src/Esfa.Vacancy.Application/Commands/CreateApprenticeship/Validators/WageTypeValidator.cs
+++ b/src/Esfa.Vacancy.Application/Commands/CreateApprenticeship/Validators/WageTypeValidator.cs
@@ -88,6 +88,21 @@ namespace Esfa.Vacancy.Application.Commands.CreateApprenticeship.Validators
                     .NotNull()
                     .WithErrorCode(ErrorCodes.CreateApprenticeship.WageTypeReason);
             });
+
+            When(request => request.WageType == WageType.ToBeSpecified, () =>
+            {
+                RuleFor(request => request.MinWage)
+                    .Null()
+                    .WithErrorCode(ErrorCodes.CreateApprenticeship.MinWage);
+
+                RuleFor(request => request.MaxWage)
+                    .Null()
+                    .WithErrorCode(ErrorCodes.CreateApprenticeship.MaxWage);
+
+                RuleFor(request => request.WageTypeReason)
+                    .NotNull()
+                    .WithErrorCode(ErrorCodes.CreateApprenticeship.WageTypeReason);
+            });
         }
     }
 }

--- a/src/Esfa.Vacancy.Application/Commands/CreateApprenticeship/Validators/WageTypeValidator.cs
+++ b/src/Esfa.Vacancy.Application/Commands/CreateApprenticeship/Validators/WageTypeValidator.cs
@@ -14,6 +14,12 @@ namespace Esfa.Vacancy.Application.Commands.CreateApprenticeship.Validators
                     .IsInEnum()
                     .WithErrorCode(ErrorCodes.CreateApprenticeship.WageType));
 
+            RuleFor(request => request.WageTypeReason)
+                .MaximumLength(240)
+                .WithErrorCode(ErrorCodes.CreateApprenticeship.WageTypeReason)
+                .MatchesAllowedFreeTextCharacters()
+                .WithErrorCode(ErrorCodes.CreateApprenticeship.WageTypeReason);
+
             When(request => request.WageType == WageType.Custom, () =>
             {
                 RuleFor(request => request.MinWage)

--- a/src/Esfa.Vacancy.Application/Commands/CreateApprenticeship/Validators/WageTypeValidator.cs
+++ b/src/Esfa.Vacancy.Application/Commands/CreateApprenticeship/Validators/WageTypeValidator.cs
@@ -58,6 +58,21 @@ namespace Esfa.Vacancy.Application.Commands.CreateApprenticeship.Validators
                     .Null()
                     .WithErrorCode(ErrorCodes.CreateApprenticeship.WageTypeReason);
             });
+
+            When(request => request.WageType == WageType.Unwaged, () =>
+            {
+                RuleFor(request => request.MinWage)
+                    .Null()
+                    .WithErrorCode(ErrorCodes.CreateApprenticeship.MinWage);
+
+                RuleFor(request => request.MaxWage)
+                    .Null()
+                    .WithErrorCode(ErrorCodes.CreateApprenticeship.MaxWage);
+
+                RuleFor(request => request.WageTypeReason)
+                    .NotNull()
+                    .WithErrorCode(ErrorCodes.CreateApprenticeship.WageTypeReason);
+            });
         }
     }
 }

--- a/src/Esfa.Vacancy.Application/Commands/CreateApprenticeship/Validators/WageTypeValidator.cs
+++ b/src/Esfa.Vacancy.Application/Commands/CreateApprenticeship/Validators/WageTypeValidator.cs
@@ -70,7 +70,7 @@ namespace Esfa.Vacancy.Application.Commands.CreateApprenticeship.Validators
                     .WithErrorCode(ErrorCodes.CreateApprenticeship.MaxWage);
 
                 RuleFor(request => request.WageTypeReason)
-                    .NotNull()
+                    .NotEmpty()
                     .WithErrorCode(ErrorCodes.CreateApprenticeship.WageTypeReason);
             });
 
@@ -85,7 +85,7 @@ namespace Esfa.Vacancy.Application.Commands.CreateApprenticeship.Validators
                     .WithErrorCode(ErrorCodes.CreateApprenticeship.MaxWage);
 
                 RuleFor(request => request.WageTypeReason)
-                    .NotNull()
+                    .NotEmpty()
                     .WithErrorCode(ErrorCodes.CreateApprenticeship.WageTypeReason);
             });
 
@@ -100,7 +100,7 @@ namespace Esfa.Vacancy.Application.Commands.CreateApprenticeship.Validators
                     .WithErrorCode(ErrorCodes.CreateApprenticeship.MaxWage);
 
                 RuleFor(request => request.WageTypeReason)
-                    .NotNull()
+                    .NotEmpty()
                     .WithErrorCode(ErrorCodes.CreateApprenticeship.WageTypeReason);
             });
 

--- a/src/Esfa.Vacancy.Application/Commands/CreateApprenticeship/Validators/WageTypeValidator.cs
+++ b/src/Esfa.Vacancy.Application/Commands/CreateApprenticeship/Validators/WageTypeValidator.cs
@@ -73,6 +73,21 @@ namespace Esfa.Vacancy.Application.Commands.CreateApprenticeship.Validators
                     .NotNull()
                     .WithErrorCode(ErrorCodes.CreateApprenticeship.WageTypeReason);
             });
+
+            When(request => request.WageType == WageType.CompetitiveSalary, () =>
+            {
+                RuleFor(request => request.MinWage)
+                    .Null()
+                    .WithErrorCode(ErrorCodes.CreateApprenticeship.MinWage);
+
+                RuleFor(request => request.MaxWage)
+                    .Null()
+                    .WithErrorCode(ErrorCodes.CreateApprenticeship.MaxWage);
+
+                RuleFor(request => request.WageTypeReason)
+                    .NotNull()
+                    .WithErrorCode(ErrorCodes.CreateApprenticeship.WageTypeReason);
+            });
         }
     }
 }

--- a/src/Esfa.Vacancy.Application/Commands/CreateApprenticeship/Validators/WageTypeValidator.cs
+++ b/src/Esfa.Vacancy.Application/Commands/CreateApprenticeship/Validators/WageTypeValidator.cs
@@ -23,6 +23,10 @@ namespace Esfa.Vacancy.Application.Commands.CreateApprenticeship.Validators
                 RuleFor(request => request.MaxWage)
                     .Null()
                     .WithErrorCode(ErrorCodes.CreateApprenticeship.MaxWage);
+
+                RuleFor(request => request.WageTypeReason)
+                    .Null()
+                    .WithErrorCode(ErrorCodes.CreateApprenticeship.WageTypeReason);
             });
 
             When(request => request.WageType == WageType.NationalMinimumWage, () =>
@@ -34,6 +38,10 @@ namespace Esfa.Vacancy.Application.Commands.CreateApprenticeship.Validators
                 RuleFor(request => request.MaxWage)
                     .Null()
                     .WithErrorCode(ErrorCodes.CreateApprenticeship.MaxWage);
+
+                RuleFor(request => request.WageTypeReason)
+                    .Null()
+                    .WithErrorCode(ErrorCodes.CreateApprenticeship.WageTypeReason);
             });
         }
     }

--- a/src/Esfa.Vacancy.Domain/Entities/CreateApprenticeshipParameters.cs
+++ b/src/Esfa.Vacancy.Domain/Entities/CreateApprenticeshipParameters.cs
@@ -12,6 +12,7 @@ namespace Esfa.Vacancy.Domain.Entities
         public string WorkingWeek { get; set; }
         public double HoursPerWeek { get; set; }
         public LegacyWageType WageType { get; set; }
+        public string WageTypeReason { get; set; }
         public int LocationTypeId { get; set; }
         public string AddressLine1 { get; set; }
         public string AddressLine2 { get; set; }

--- a/src/Esfa.Vacancy.Domain/Validation/ErrorCodes.cs
+++ b/src/Esfa.Vacancy.Domain/Validation/ErrorCodes.cs
@@ -60,6 +60,7 @@
             public const string WorkingWeek = "31006";
             public const string HoursPerWeek = "31007";
             public const string WageType = "31008";
+            public const string WageTypeReason = "31123";
             public const string MinWage = "31009";
             public const string MaxWage = "31010";
             public const string LocationType = "31011";
@@ -75,7 +76,6 @@
             public const string EmployerEdsUrn = "31021";
             public const string ProviderSiteEdsUrn = "31022";
             public const string ContactName = "31201";
-            public const string WageTypeReason = "31023";
             public const string ContactEmail = "31202";
             public const string ContactNumber = "31203";
         }

--- a/src/Esfa.Vacancy.Domain/Validation/ErrorCodes.cs
+++ b/src/Esfa.Vacancy.Domain/Validation/ErrorCodes.cs
@@ -75,6 +75,7 @@
             public const string EmployerEdsUrn = "31021";
             public const string ProviderSiteEdsUrn = "31022";
             public const string ContactName = "31201";
+            public const string WageTypeReason = "31023";
             public const string ContactEmail = "31202";
             public const string ContactNumber = "31203";
         }

--- a/src/Esfa.Vacancy.Manage.Api/Mappings/CreateApprenticeshipRequestMapper.cs
+++ b/src/Esfa.Vacancy.Manage.Api/Mappings/CreateApprenticeshipRequestMapper.cs
@@ -20,6 +20,7 @@ namespace Esfa.Vacancy.Manage.Api.Mappings
                 WorkingWeek = parameters.WorkingWeek,
                 HoursPerWeek = parameters.HoursPerWeek,
                 WageType = (ApplicationTypes.WageType)parameters.WageType,
+                WageTypeReason = parameters.WageTypeReason,
                 MinWage = parameters.MinWage,
                 MaxWage = parameters.MaxWage,
                 LocationType = (ApplicationTypes.LocationType)parameters.LocationType,

--- a/src/Esfa.Vacancy.UnitTests/CreateApprenticeship/Api/Mappings/GivenACreateApprenticeshipRequestMapper/WhenMappingFromApiParameters.cs
+++ b/src/Esfa.Vacancy.UnitTests/CreateApprenticeship/Api/Mappings/GivenACreateApprenticeshipRequestMapper/WhenMappingFromApiParameters.cs
@@ -81,6 +81,12 @@ namespace Esfa.Vacancy.UnitTests.CreateApprenticeship.Api.Mappings.GivenACreateA
         }
 
         [Test]
+        public void ThenMapsWageTypeReason()
+        {
+            _mappedRequest.WageTypeReason.Should().Be(_apiParameters.WageTypeReason);
+        }
+
+        [Test]
         public void ThenMapsMinWage()
         {
             _mappedRequest.MinWage.Should().Be(_apiParameters.MinWage);

--- a/src/Esfa.Vacancy.UnitTests/CreateApprenticeship/Application/GivenACreateApprenticeshipParametersMapper/WhenMappingFromARequest.cs
+++ b/src/Esfa.Vacancy.UnitTests/CreateApprenticeship/Application/GivenACreateApprenticeshipParametersMapper/WhenMappingFromARequest.cs
@@ -91,6 +91,12 @@ namespace Esfa.Vacancy.UnitTests.CreateApprenticeship.Application.GivenACreateAp
         }
 
         [Test]
+        public void ThenMapsWageTypeReason()
+        {
+            _mappedParameters.WageTypeReason.Should().Be(_request.WageTypeReason);
+        }
+
+        [Test]
         public void ThenMapsNumberOfPositions()
         {
             _mappedParameters.NumberOfPositions.Should().Be(_request.NumberOfPositions);

--- a/src/Esfa.Vacancy.UnitTests/CreateApprenticeship/Application/GivenACreateApprenticeshipRequestValidator/AndWageTypeApprenticeshipMinimumWage/WhenValidatingWageTypeReason.cs
+++ b/src/Esfa.Vacancy.UnitTests/CreateApprenticeship/Application/GivenACreateApprenticeshipRequestValidator/AndWageTypeApprenticeshipMinimumWage/WhenValidatingWageTypeReason.cs
@@ -44,7 +44,7 @@ namespace Esfa.Vacancy.UnitTests.CreateApprenticeship.Application.GivenACreateAp
                 WageType = WageType.ApprenticeshipMinimumWage
             };
 
-            var context = GetValidationContextForProperty(request, req => req.MaxWage);
+            var context = GetValidationContextForProperty(request, req => req.WageTypeReason);
 
             var validator = fixture.Create<CreateApprenticeshipRequestValidator>();
 

--- a/src/Esfa.Vacancy.UnitTests/CreateApprenticeship/Application/GivenACreateApprenticeshipRequestValidator/AndWageTypeApprenticeshipMinimumWage/WhenValidatingWageTypeReason.cs
+++ b/src/Esfa.Vacancy.UnitTests/CreateApprenticeship/Application/GivenACreateApprenticeshipRequestValidator/AndWageTypeApprenticeshipMinimumWage/WhenValidatingWageTypeReason.cs
@@ -1,0 +1,56 @@
+﻿using System.Linq;
+using System.Threading.Tasks;
+using Esfa.Vacancy.Application.Commands.CreateApprenticeship;
+using Esfa.Vacancy.Application.Commands.CreateApprenticeship.Validators;
+using Esfa.Vacancy.Domain.Validation;
+using FluentAssertions;
+using NUnit.Framework;
+using Ploeh.AutoFixture;
+
+namespace Esfa.Vacancy.UnitTests.CreateApprenticeship.Application.GivenACreateApprenticeshipRequestValidator.AndWageTypeApprenticeshipMinimumWage
+{
+    [TestFixture]
+    public class WhenValidatingWageTypeReason : CreateApprenticeshipRequestValidatorBase
+    {
+        [Test]
+        public async Task AndHasValueThenIsInvalid()
+        {
+            var fixture = new Fixture();
+            var request = new CreateApprenticeshipRequest
+            {
+                WageType = WageType.ApprenticeshipMinimumWage,
+                WageTypeReason = fixture.Create<string>()
+            };
+
+            var context = GetValidationContextForProperty(request, req => req.WageTypeReason);
+
+            var validator = fixture.Create<CreateApprenticeshipRequestValidator>();
+
+            var result = await validator.ValidateAsync(context);
+
+            result.IsValid.Should().Be(false);
+            result.Errors.First().ErrorCode
+                .Should().Be(ErrorCodes.CreateApprenticeship.WageTypeReason);
+            result.Errors.First().ErrorMessage
+                .Should().Be("'Wage Type Reason' must be empty.");
+        }
+
+        [Test]
+        public async Task AndNoValueThenIsValid()
+        {
+            var fixture = new Fixture();
+            var request = new CreateApprenticeshipRequest
+            {
+                WageType = WageType.ApprenticeshipMinimumWage
+            };
+
+            var context = GetValidationContextForProperty(request, req => req.MaxWage);
+
+            var validator = fixture.Create<CreateApprenticeshipRequestValidator>();
+
+            var result = await validator.ValidateAsync(context);
+
+            result.IsValid.Should().Be(true);
+        }
+    }
+}

--- a/src/Esfa.Vacancy.UnitTests/CreateApprenticeship/Application/GivenACreateApprenticeshipRequestValidator/AndWageTypeCompetitiveSalary/WhenValidatingMaxWage.cs
+++ b/src/Esfa.Vacancy.UnitTests/CreateApprenticeship/Application/GivenACreateApprenticeshipRequestValidator/AndWageTypeCompetitiveSalary/WhenValidatingMaxWage.cs
@@ -1,0 +1,56 @@
+﻿using System.Linq;
+using System.Threading.Tasks;
+using Esfa.Vacancy.Application.Commands.CreateApprenticeship;
+using Esfa.Vacancy.Application.Commands.CreateApprenticeship.Validators;
+using Esfa.Vacancy.Domain.Validation;
+using FluentAssertions;
+using NUnit.Framework;
+using Ploeh.AutoFixture;
+
+namespace Esfa.Vacancy.UnitTests.CreateApprenticeship.Application.GivenACreateApprenticeshipRequestValidator.AndWageTypeCompetitiveSalary
+{
+    [TestFixture]
+    public class WhenValidatingMaxWage : CreateApprenticeshipRequestValidatorBase
+    {
+        [Test]
+        public async Task AndHasValueThenIsInvalid()
+        {
+            var fixture = new Fixture();
+            var request = new CreateApprenticeshipRequest
+            {
+                WageType = WageType.CompetitiveSalary,
+                MaxWage = fixture.Create<decimal>()
+            };
+
+            var context = GetValidationContextForProperty(request, req => req.MaxWage);
+
+            var validator = fixture.Create<CreateApprenticeshipRequestValidator>();
+
+            var result = await validator.ValidateAsync(context);
+
+            result.IsValid.Should().Be(false);
+            result.Errors.First().ErrorCode
+                .Should().Be(ErrorCodes.CreateApprenticeship.MaxWage);
+            result.Errors.First().ErrorMessage
+                .Should().Be("'Max Wage' must be empty.");
+        }
+
+        [Test]
+        public async Task AndNoValueThenIsValid()
+        {
+            var fixture = new Fixture();
+            var request = new CreateApprenticeshipRequest
+            {
+                WageType = WageType.CompetitiveSalary
+            };
+
+            var context = GetValidationContextForProperty(request, req => req.MaxWage);
+
+            var validator = fixture.Create<CreateApprenticeshipRequestValidator>();
+
+            var result = await validator.ValidateAsync(context);
+
+            result.IsValid.Should().Be(true);
+        }
+    }
+}

--- a/src/Esfa.Vacancy.UnitTests/CreateApprenticeship/Application/GivenACreateApprenticeshipRequestValidator/AndWageTypeCompetitiveSalary/WhenValidatingMinWage.cs
+++ b/src/Esfa.Vacancy.UnitTests/CreateApprenticeship/Application/GivenACreateApprenticeshipRequestValidator/AndWageTypeCompetitiveSalary/WhenValidatingMinWage.cs
@@ -1,0 +1,56 @@
+﻿using System.Linq;
+using System.Threading.Tasks;
+using Esfa.Vacancy.Application.Commands.CreateApprenticeship;
+using Esfa.Vacancy.Application.Commands.CreateApprenticeship.Validators;
+using Esfa.Vacancy.Domain.Validation;
+using FluentAssertions;
+using NUnit.Framework;
+using Ploeh.AutoFixture;
+
+namespace Esfa.Vacancy.UnitTests.CreateApprenticeship.Application.GivenACreateApprenticeshipRequestValidator.AndWageTypeCompetitiveSalary
+{
+    [TestFixture]
+    public class WhenValidatingMinWage : CreateApprenticeshipRequestValidatorBase
+    {
+        [Test]
+        public async Task AndHasValueThenIsInvalid()
+        {
+            var fixture = new Fixture();
+            var request = new CreateApprenticeshipRequest
+            {
+                WageType = WageType.CompetitiveSalary,
+                MinWage = fixture.Create<decimal>()
+            };
+
+            var context = GetValidationContextForProperty(request, req => req.MinWage);
+
+            var validator = fixture.Create<CreateApprenticeshipRequestValidator>();
+
+            var result = await validator.ValidateAsync(context);
+
+            result.IsValid.Should().Be(false);
+            result.Errors.First().ErrorCode
+                .Should().Be(ErrorCodes.CreateApprenticeship.MinWage);
+            result.Errors.First().ErrorMessage
+                .Should().Be("'Min Wage' must be empty.");
+        }
+
+        [Test]
+        public async Task AndNoValueThenIsValid()
+        {
+            var fixture = new Fixture();
+            var request = new CreateApprenticeshipRequest
+            {
+                WageType = WageType.CompetitiveSalary
+            };
+
+            var context = GetValidationContextForProperty(request, req => req.MinWage);
+
+            var validator = fixture.Create<CreateApprenticeshipRequestValidator>();
+
+            var result = await validator.ValidateAsync(context);
+
+            result.IsValid.Should().Be(true);
+        }
+    }
+}

--- a/src/Esfa.Vacancy.UnitTests/CreateApprenticeship/Application/GivenACreateApprenticeshipRequestValidator/AndWageTypeCompetitiveSalary/WhenValidatingWageTypeReason.cs
+++ b/src/Esfa.Vacancy.UnitTests/CreateApprenticeship/Application/GivenACreateApprenticeshipRequestValidator/AndWageTypeCompetitiveSalary/WhenValidatingWageTypeReason.cs
@@ -13,7 +13,7 @@ namespace Esfa.Vacancy.UnitTests.CreateApprenticeship.Application.GivenACreateAp
     public class WhenValidatingWageTypeReason : CreateApprenticeshipRequestValidatorBase
     {
         [Test]
-        public async Task AndHasValueThenIsInvalid()
+        public async Task AndNoValueThenIsInvalid()
         {
             var fixture = new Fixture();
             var request = new CreateApprenticeshipRequest
@@ -31,11 +31,34 @@ namespace Esfa.Vacancy.UnitTests.CreateApprenticeship.Application.GivenACreateAp
             result.Errors.First().ErrorCode
                 .Should().Be(ErrorCodes.CreateApprenticeship.WageTypeReason);
             result.Errors.First().ErrorMessage
-                .Should().Be("'Wage Type Reason' must not be empty.");
+                .Should().Be("'Wage Type Reason' should not be empty.");
         }
 
         [Test]
-        public async Task AndNoValueThenIsValid()
+        public async Task AndEmptyStringValueThenIsInvalid()
+        {
+            var fixture = new Fixture();
+            var request = new CreateApprenticeshipRequest
+            {
+                WageType = WageType.CompetitiveSalary,
+                WageTypeReason = ""
+            };
+
+            var context = GetValidationContextForProperty(request, req => req.WageTypeReason);
+
+            var validator = fixture.Create<CreateApprenticeshipRequestValidator>();
+
+            var result = await validator.ValidateAsync(context);
+
+            result.IsValid.Should().Be(false);
+            result.Errors.First().ErrorCode
+                .Should().Be(ErrorCodes.CreateApprenticeship.WageTypeReason);
+            result.Errors.First().ErrorMessage
+                .Should().Be("'Wage Type Reason' should not be empty.");
+        }
+
+        [Test]
+        public async Task AndHasValueThenIsValid()
         {
             var fixture = new Fixture();
             var request = new CreateApprenticeshipRequest

--- a/src/Esfa.Vacancy.UnitTests/CreateApprenticeship/Application/GivenACreateApprenticeshipRequestValidator/AndWageTypeCompetitiveSalary/WhenValidatingWageTypeReason.cs
+++ b/src/Esfa.Vacancy.UnitTests/CreateApprenticeship/Application/GivenACreateApprenticeshipRequestValidator/AndWageTypeCompetitiveSalary/WhenValidatingWageTypeReason.cs
@@ -1,0 +1,56 @@
+﻿using System.Linq;
+using System.Threading.Tasks;
+using Esfa.Vacancy.Application.Commands.CreateApprenticeship;
+using Esfa.Vacancy.Application.Commands.CreateApprenticeship.Validators;
+using Esfa.Vacancy.Domain.Validation;
+using FluentAssertions;
+using NUnit.Framework;
+using Ploeh.AutoFixture;
+
+namespace Esfa.Vacancy.UnitTests.CreateApprenticeship.Application.GivenACreateApprenticeshipRequestValidator.AndWageTypeCompetitiveSalary
+{
+    [TestFixture]
+    public class WhenValidatingWageTypeReason : CreateApprenticeshipRequestValidatorBase
+    {
+        [Test]
+        public async Task AndHasValueThenIsInvalid()
+        {
+            var fixture = new Fixture();
+            var request = new CreateApprenticeshipRequest
+            {
+                WageType = WageType.CompetitiveSalary
+            };
+
+            var context = GetValidationContextForProperty(request, req => req.WageTypeReason);
+
+            var validator = fixture.Create<CreateApprenticeshipRequestValidator>();
+
+            var result = await validator.ValidateAsync(context);
+
+            result.IsValid.Should().Be(false);
+            result.Errors.First().ErrorCode
+                .Should().Be(ErrorCodes.CreateApprenticeship.WageTypeReason);
+            result.Errors.First().ErrorMessage
+                .Should().Be("'Wage Type Reason' must not be empty.");
+        }
+
+        [Test]
+        public async Task AndNoValueThenIsValid()
+        {
+            var fixture = new Fixture();
+            var request = new CreateApprenticeshipRequest
+            {
+                WageType = WageType.CompetitiveSalary,
+                WageTypeReason = fixture.Create<string>()
+            };
+
+            var context = GetValidationContextForProperty(request, req => req.WageTypeReason);
+
+            var validator = fixture.Create<CreateApprenticeshipRequestValidator>();
+
+            var result = await validator.ValidateAsync(context);
+
+            result.IsValid.Should().Be(true);
+        }
+    }
+}

--- a/src/Esfa.Vacancy.UnitTests/CreateApprenticeship/Application/GivenACreateApprenticeshipRequestValidator/AndWageTypeCustom/WhenValidatingMaxWage.cs
+++ b/src/Esfa.Vacancy.UnitTests/CreateApprenticeship/Application/GivenACreateApprenticeshipRequestValidator/AndWageTypeCustom/WhenValidatingMaxWage.cs
@@ -7,22 +7,21 @@ using FluentAssertions;
 using NUnit.Framework;
 using Ploeh.AutoFixture;
 
-namespace Esfa.Vacancy.UnitTests.CreateApprenticeship.Application.GivenACreateApprenticeshipRequestValidator.AndWageTypeNationalMinimumWage
+namespace Esfa.Vacancy.UnitTests.CreateApprenticeship.Application.GivenACreateApprenticeshipRequestValidator.AndWageTypeCustom
 {
     [TestFixture]
-    public class WhenValidatingWageTypeReason : CreateApprenticeshipRequestValidatorBase
+    public class WhenValidatingMaxWage : CreateApprenticeshipRequestValidatorBase
     {
         [Test]
-        public async Task AndHasValueThenIsInvalid()
+        public async Task AndNoValueThenIsInValid()
         {
             var fixture = new Fixture();
             var request = new CreateApprenticeshipRequest
             {
-                WageType = WageType.NationalMinimumWage,
-                WageTypeReason = fixture.Create<string>()
+                WageType = WageType.Custom
             };
 
-            var context = GetValidationContextForProperty(request, req => req.WageTypeReason);
+            var context = GetValidationContextForProperty(request, req => req.MaxWage);
 
             var validator = fixture.Create<CreateApprenticeshipRequestValidator>();
 
@@ -30,21 +29,22 @@ namespace Esfa.Vacancy.UnitTests.CreateApprenticeship.Application.GivenACreateAp
 
             result.IsValid.Should().Be(false);
             result.Errors.First().ErrorCode
-                .Should().Be(ErrorCodes.CreateApprenticeship.WageTypeReason);
+                .Should().Be(ErrorCodes.CreateApprenticeship.MaxWage);
             result.Errors.First().ErrorMessage
-                .Should().Be("'Wage Type Reason' must be empty.");
+                .Should().Be("'Max Wage' must not be empty.");
         }
 
         [Test]
-        public async Task AndNoValueThenIsValid()
+        public async Task AndHasValueThenIsValid()
         {
             var fixture = new Fixture();
             var request = new CreateApprenticeshipRequest
             {
-                WageType = WageType.NationalMinimumWage
+                WageType = WageType.Custom,
+                MaxWage = fixture.Create<decimal>()
             };
 
-            var context = GetValidationContextForProperty(request, req => req.WageTypeReason);
+            var context = GetValidationContextForProperty(request, req => req.MaxWage);
 
             var validator = fixture.Create<CreateApprenticeshipRequestValidator>();
 

--- a/src/Esfa.Vacancy.UnitTests/CreateApprenticeship/Application/GivenACreateApprenticeshipRequestValidator/AndWageTypeCustom/WhenValidatingMinWage.cs
+++ b/src/Esfa.Vacancy.UnitTests/CreateApprenticeship/Application/GivenACreateApprenticeshipRequestValidator/AndWageTypeCustom/WhenValidatingMinWage.cs
@@ -7,22 +7,21 @@ using FluentAssertions;
 using NUnit.Framework;
 using Ploeh.AutoFixture;
 
-namespace Esfa.Vacancy.UnitTests.CreateApprenticeship.Application.GivenACreateApprenticeshipRequestValidator.AndWageTypeNationalMinimumWage
+namespace Esfa.Vacancy.UnitTests.CreateApprenticeship.Application.GivenACreateApprenticeshipRequestValidator.AndWageTypeCustom
 {
     [TestFixture]
-    public class WhenValidatingWageTypeReason : CreateApprenticeshipRequestValidatorBase
+    public class WhenValidatingMinWage : CreateApprenticeshipRequestValidatorBase
     {
         [Test]
-        public async Task AndHasValueThenIsInvalid()
+        public async Task AndNoValueThenIsInValid()
         {
             var fixture = new Fixture();
             var request = new CreateApprenticeshipRequest
             {
-                WageType = WageType.NationalMinimumWage,
-                WageTypeReason = fixture.Create<string>()
+                WageType = WageType.Custom
             };
 
-            var context = GetValidationContextForProperty(request, req => req.WageTypeReason);
+            var context = GetValidationContextForProperty(request, req => req.MinWage);
 
             var validator = fixture.Create<CreateApprenticeshipRequestValidator>();
 
@@ -30,21 +29,22 @@ namespace Esfa.Vacancy.UnitTests.CreateApprenticeship.Application.GivenACreateAp
 
             result.IsValid.Should().Be(false);
             result.Errors.First().ErrorCode
-                .Should().Be(ErrorCodes.CreateApprenticeship.WageTypeReason);
+                .Should().Be(ErrorCodes.CreateApprenticeship.MinWage);
             result.Errors.First().ErrorMessage
-                .Should().Be("'Wage Type Reason' must be empty.");
+                .Should().Be("'Min Wage' must not be empty.");
         }
 
         [Test]
-        public async Task AndNoValueThenIsValid()
+        public async Task AndHasValueThenIsValid()
         {
             var fixture = new Fixture();
             var request = new CreateApprenticeshipRequest
             {
-                WageType = WageType.NationalMinimumWage
+                WageType = WageType.Custom,
+                MinWage = fixture.Create<decimal>()
             };
 
-            var context = GetValidationContextForProperty(request, req => req.WageTypeReason);
+            var context = GetValidationContextForProperty(request, req => req.MinWage);
 
             var validator = fixture.Create<CreateApprenticeshipRequestValidator>();
 

--- a/src/Esfa.Vacancy.UnitTests/CreateApprenticeship/Application/GivenACreateApprenticeshipRequestValidator/AndWageTypeCustom/WhenValidatingWageTypeReason.cs
+++ b/src/Esfa.Vacancy.UnitTests/CreateApprenticeship/Application/GivenACreateApprenticeshipRequestValidator/AndWageTypeCustom/WhenValidatingWageTypeReason.cs
@@ -7,7 +7,7 @@ using FluentAssertions;
 using NUnit.Framework;
 using Ploeh.AutoFixture;
 
-namespace Esfa.Vacancy.UnitTests.CreateApprenticeship.Application.GivenACreateApprenticeshipRequestValidator.AndWageTypeNationalMinimumWage
+namespace Esfa.Vacancy.UnitTests.CreateApprenticeship.Application.GivenACreateApprenticeshipRequestValidator.AndWageTypeCustom
 {
     [TestFixture]
     public class WhenValidatingWageTypeReason : CreateApprenticeshipRequestValidatorBase
@@ -18,7 +18,7 @@ namespace Esfa.Vacancy.UnitTests.CreateApprenticeship.Application.GivenACreateAp
             var fixture = new Fixture();
             var request = new CreateApprenticeshipRequest
             {
-                WageType = WageType.NationalMinimumWage,
+                WageType = WageType.Custom,
                 WageTypeReason = fixture.Create<string>()
             };
 
@@ -41,7 +41,7 @@ namespace Esfa.Vacancy.UnitTests.CreateApprenticeship.Application.GivenACreateAp
             var fixture = new Fixture();
             var request = new CreateApprenticeshipRequest
             {
-                WageType = WageType.NationalMinimumWage
+                WageType = WageType.Custom
             };
 
             var context = GetValidationContextForProperty(request, req => req.WageTypeReason);

--- a/src/Esfa.Vacancy.UnitTests/CreateApprenticeship/Application/GivenACreateApprenticeshipRequestValidator/AndWageTypeNationalMinimumWage/WhenValidatingWageTypeReason.cs
+++ b/src/Esfa.Vacancy.UnitTests/CreateApprenticeship/Application/GivenACreateApprenticeshipRequestValidator/AndWageTypeNationalMinimumWage/WhenValidatingWageTypeReason.cs
@@ -1,0 +1,56 @@
+﻿using System.Linq;
+using System.Threading.Tasks;
+using Esfa.Vacancy.Application.Commands.CreateApprenticeship;
+using Esfa.Vacancy.Application.Commands.CreateApprenticeship.Validators;
+using Esfa.Vacancy.Domain.Validation;
+using FluentAssertions;
+using NUnit.Framework;
+using Ploeh.AutoFixture;
+
+namespace Esfa.Vacancy.UnitTests.CreateApprenticeship.Application.GivenACreateApprenticeshipRequestValidator.AndWageTypeNationalMinimumWage
+{
+    [TestFixture]
+    public class WhenValidatingWageTypeReason : CreateApprenticeshipRequestValidatorBase
+    {
+        [Test]
+        public async Task AndHasValueThenIsInvalid()
+        {
+            var fixture = new Fixture();
+            var request = new CreateApprenticeshipRequest
+            {
+                WageType = WageType.NationalMinimumWage,
+                WageTypeReason = fixture.Create<string>()
+            };
+
+            var context = GetValidationContextForProperty(request, req => req.WageTypeReason);
+
+            var validator = fixture.Create<CreateApprenticeshipRequestValidator>();
+
+            var result = await validator.ValidateAsync(context);
+
+            result.IsValid.Should().Be(false);
+            result.Errors.First().ErrorCode
+                .Should().Be(ErrorCodes.CreateApprenticeship.WageTypeReason);
+            result.Errors.First().ErrorMessage
+                .Should().Be("'Wage Type Reason' must be empty.");
+        }
+
+        [Test]
+        public async Task AndNoValueThenIsValid()
+        {
+            var fixture = new Fixture();
+            var request = new CreateApprenticeshipRequest
+            {
+                WageType = WageType.NationalMinimumWage
+            };
+
+            var context = GetValidationContextForProperty(request, req => req.MaxWage);
+
+            var validator = fixture.Create<CreateApprenticeshipRequestValidator>();
+
+            var result = await validator.ValidateAsync(context);
+
+            result.IsValid.Should().Be(true);
+        }
+    }
+}

--- a/src/Esfa.Vacancy.UnitTests/CreateApprenticeship/Application/GivenACreateApprenticeshipRequestValidator/AndWageTypeToBeSpecified/WhenValidatingMaxWage.cs
+++ b/src/Esfa.Vacancy.UnitTests/CreateApprenticeship/Application/GivenACreateApprenticeshipRequestValidator/AndWageTypeToBeSpecified/WhenValidatingMaxWage.cs
@@ -1,0 +1,56 @@
+﻿using System.Linq;
+using System.Threading.Tasks;
+using Esfa.Vacancy.Application.Commands.CreateApprenticeship;
+using Esfa.Vacancy.Application.Commands.CreateApprenticeship.Validators;
+using Esfa.Vacancy.Domain.Validation;
+using FluentAssertions;
+using NUnit.Framework;
+using Ploeh.AutoFixture;
+
+namespace Esfa.Vacancy.UnitTests.CreateApprenticeship.Application.GivenACreateApprenticeshipRequestValidator.AndWageTypeToBeSpecified
+{
+    [TestFixture]
+    public class WhenValidatingMaxWage : CreateApprenticeshipRequestValidatorBase
+    {
+        [Test]
+        public async Task AndHasValueThenIsInvalid()
+        {
+            var fixture = new Fixture();
+            var request = new CreateApprenticeshipRequest
+            {
+                WageType = WageType.ToBeSpecified,
+                MaxWage = fixture.Create<decimal>()
+            };
+
+            var context = GetValidationContextForProperty(request, req => req.MaxWage);
+
+            var validator = fixture.Create<CreateApprenticeshipRequestValidator>();
+
+            var result = await validator.ValidateAsync(context);
+
+            result.IsValid.Should().Be(false);
+            result.Errors.First().ErrorCode
+                .Should().Be(ErrorCodes.CreateApprenticeship.MaxWage);
+            result.Errors.First().ErrorMessage
+                .Should().Be("'Max Wage' must be empty.");
+        }
+
+        [Test]
+        public async Task AndNoValueThenIsValid()
+        {
+            var fixture = new Fixture();
+            var request = new CreateApprenticeshipRequest
+            {
+                WageType = WageType.ToBeSpecified
+            };
+
+            var context = GetValidationContextForProperty(request, req => req.MaxWage);
+
+            var validator = fixture.Create<CreateApprenticeshipRequestValidator>();
+
+            var result = await validator.ValidateAsync(context);
+
+            result.IsValid.Should().Be(true);
+        }
+    }
+}

--- a/src/Esfa.Vacancy.UnitTests/CreateApprenticeship/Application/GivenACreateApprenticeshipRequestValidator/AndWageTypeToBeSpecified/WhenValidatingMinWage.cs
+++ b/src/Esfa.Vacancy.UnitTests/CreateApprenticeship/Application/GivenACreateApprenticeshipRequestValidator/AndWageTypeToBeSpecified/WhenValidatingMinWage.cs
@@ -1,0 +1,56 @@
+﻿using System.Linq;
+using System.Threading.Tasks;
+using Esfa.Vacancy.Application.Commands.CreateApprenticeship;
+using Esfa.Vacancy.Application.Commands.CreateApprenticeship.Validators;
+using Esfa.Vacancy.Domain.Validation;
+using FluentAssertions;
+using NUnit.Framework;
+using Ploeh.AutoFixture;
+
+namespace Esfa.Vacancy.UnitTests.CreateApprenticeship.Application.GivenACreateApprenticeshipRequestValidator.AndWageTypeToBeSpecified
+{
+    [TestFixture]
+    public class WhenValidatingMinWage : CreateApprenticeshipRequestValidatorBase
+    {
+        [Test]
+        public async Task AndHasValueThenIsInvalid()
+        {
+            var fixture = new Fixture();
+            var request = new CreateApprenticeshipRequest
+            {
+                WageType = WageType.ToBeSpecified,
+                MinWage = fixture.Create<decimal>()
+            };
+
+            var context = GetValidationContextForProperty(request, req => req.MinWage);
+
+            var validator = fixture.Create<CreateApprenticeshipRequestValidator>();
+
+            var result = await validator.ValidateAsync(context);
+
+            result.IsValid.Should().Be(false);
+            result.Errors.First().ErrorCode
+                .Should().Be(ErrorCodes.CreateApprenticeship.MinWage);
+            result.Errors.First().ErrorMessage
+                .Should().Be("'Min Wage' must be empty.");
+        }
+
+        [Test]
+        public async Task AndNoValueThenIsValid()
+        {
+            var fixture = new Fixture();
+            var request = new CreateApprenticeshipRequest
+            {
+                WageType = WageType.ToBeSpecified
+            };
+
+            var context = GetValidationContextForProperty(request, req => req.MinWage);
+
+            var validator = fixture.Create<CreateApprenticeshipRequestValidator>();
+
+            var result = await validator.ValidateAsync(context);
+
+            result.IsValid.Should().Be(true);
+        }
+    }
+}

--- a/src/Esfa.Vacancy.UnitTests/CreateApprenticeship/Application/GivenACreateApprenticeshipRequestValidator/AndWageTypeToBeSpecified/WhenValidatingWageTypeReason.cs
+++ b/src/Esfa.Vacancy.UnitTests/CreateApprenticeship/Application/GivenACreateApprenticeshipRequestValidator/AndWageTypeToBeSpecified/WhenValidatingWageTypeReason.cs
@@ -13,7 +13,7 @@ namespace Esfa.Vacancy.UnitTests.CreateApprenticeship.Application.GivenACreateAp
     public class WhenValidatingWageTypeReason : CreateApprenticeshipRequestValidatorBase
     {
         [Test]
-        public async Task AndHasValueThenIsInvalid()
+        public async Task AndNoValueThenIsInvalid()
         {
             var fixture = new Fixture();
             var request = new CreateApprenticeshipRequest
@@ -31,11 +31,34 @@ namespace Esfa.Vacancy.UnitTests.CreateApprenticeship.Application.GivenACreateAp
             result.Errors.First().ErrorCode
                 .Should().Be(ErrorCodes.CreateApprenticeship.WageTypeReason);
             result.Errors.First().ErrorMessage
-                .Should().Be("'Wage Type Reason' must not be empty.");
+                .Should().Be("'Wage Type Reason' should not be empty.");
         }
 
         [Test]
-        public async Task AndNoValueThenIsValid()
+        public async Task AndEmptyStringValueThenIsInvalid()
+        {
+            var fixture = new Fixture();
+            var request = new CreateApprenticeshipRequest
+            {
+                WageType = WageType.ToBeSpecified,
+                WageTypeReason = ""
+            };
+
+            var context = GetValidationContextForProperty(request, req => req.WageTypeReason);
+
+            var validator = fixture.Create<CreateApprenticeshipRequestValidator>();
+
+            var result = await validator.ValidateAsync(context);
+
+            result.IsValid.Should().Be(false);
+            result.Errors.First().ErrorCode
+                .Should().Be(ErrorCodes.CreateApprenticeship.WageTypeReason);
+            result.Errors.First().ErrorMessage
+                .Should().Be("'Wage Type Reason' should not be empty.");
+        }
+
+        [Test]
+        public async Task AndHasValueThenIsValid()
         {
             var fixture = new Fixture();
             var request = new CreateApprenticeshipRequest

--- a/src/Esfa.Vacancy.UnitTests/CreateApprenticeship/Application/GivenACreateApprenticeshipRequestValidator/AndWageTypeToBeSpecified/WhenValidatingWageTypeReason.cs
+++ b/src/Esfa.Vacancy.UnitTests/CreateApprenticeship/Application/GivenACreateApprenticeshipRequestValidator/AndWageTypeToBeSpecified/WhenValidatingWageTypeReason.cs
@@ -1,0 +1,56 @@
+﻿using System.Linq;
+using System.Threading.Tasks;
+using Esfa.Vacancy.Application.Commands.CreateApprenticeship;
+using Esfa.Vacancy.Application.Commands.CreateApprenticeship.Validators;
+using Esfa.Vacancy.Domain.Validation;
+using FluentAssertions;
+using NUnit.Framework;
+using Ploeh.AutoFixture;
+
+namespace Esfa.Vacancy.UnitTests.CreateApprenticeship.Application.GivenACreateApprenticeshipRequestValidator.AndWageTypeToBeSpecified
+{
+    [TestFixture]
+    public class WhenValidatingWageTypeReason : CreateApprenticeshipRequestValidatorBase
+    {
+        [Test]
+        public async Task AndHasValueThenIsInvalid()
+        {
+            var fixture = new Fixture();
+            var request = new CreateApprenticeshipRequest
+            {
+                WageType = WageType.ToBeSpecified
+            };
+
+            var context = GetValidationContextForProperty(request, req => req.WageTypeReason);
+
+            var validator = fixture.Create<CreateApprenticeshipRequestValidator>();
+
+            var result = await validator.ValidateAsync(context);
+
+            result.IsValid.Should().Be(false);
+            result.Errors.First().ErrorCode
+                .Should().Be(ErrorCodes.CreateApprenticeship.WageTypeReason);
+            result.Errors.First().ErrorMessage
+                .Should().Be("'Wage Type Reason' must not be empty.");
+        }
+
+        [Test]
+        public async Task AndNoValueThenIsValid()
+        {
+            var fixture = new Fixture();
+            var request = new CreateApprenticeshipRequest
+            {
+                WageType = WageType.ToBeSpecified,
+                WageTypeReason = fixture.Create<string>()
+            };
+
+            var context = GetValidationContextForProperty(request, req => req.WageTypeReason);
+
+            var validator = fixture.Create<CreateApprenticeshipRequestValidator>();
+
+            var result = await validator.ValidateAsync(context);
+
+            result.IsValid.Should().Be(true);
+        }
+    }
+}

--- a/src/Esfa.Vacancy.UnitTests/CreateApprenticeship/Application/GivenACreateApprenticeshipRequestValidator/AndWageTypeUnwaged/WhenValidatingMaxWage.cs
+++ b/src/Esfa.Vacancy.UnitTests/CreateApprenticeship/Application/GivenACreateApprenticeshipRequestValidator/AndWageTypeUnwaged/WhenValidatingMaxWage.cs
@@ -1,0 +1,56 @@
+﻿using System.Linq;
+using System.Threading.Tasks;
+using Esfa.Vacancy.Application.Commands.CreateApprenticeship;
+using Esfa.Vacancy.Application.Commands.CreateApprenticeship.Validators;
+using Esfa.Vacancy.Domain.Validation;
+using FluentAssertions;
+using NUnit.Framework;
+using Ploeh.AutoFixture;
+
+namespace Esfa.Vacancy.UnitTests.CreateApprenticeship.Application.GivenACreateApprenticeshipRequestValidator.AndWageTypeUnwaged
+{
+    [TestFixture]
+    public class WhenValidatingMaxWage : CreateApprenticeshipRequestValidatorBase
+    {
+        [Test]
+        public async Task AndHasValueThenIsInvalid()
+        {
+            var fixture = new Fixture();
+            var request = new CreateApprenticeshipRequest
+            {
+                WageType = WageType.Unwaged,
+                MaxWage = fixture.Create<decimal>()
+            };
+
+            var context = GetValidationContextForProperty(request, req => req.MaxWage);
+
+            var validator = fixture.Create<CreateApprenticeshipRequestValidator>();
+
+            var result = await validator.ValidateAsync(context);
+
+            result.IsValid.Should().Be(false);
+            result.Errors.First().ErrorCode
+                .Should().Be(ErrorCodes.CreateApprenticeship.MaxWage);
+            result.Errors.First().ErrorMessage
+                .Should().Be("'Max Wage' must be empty.");
+        }
+
+        [Test]
+        public async Task AndNoValueThenIsValid()
+        {
+            var fixture = new Fixture();
+            var request = new CreateApprenticeshipRequest
+            {
+                WageType = WageType.Unwaged
+            };
+
+            var context = GetValidationContextForProperty(request, req => req.MaxWage);
+
+            var validator = fixture.Create<CreateApprenticeshipRequestValidator>();
+
+            var result = await validator.ValidateAsync(context);
+
+            result.IsValid.Should().Be(true);
+        }
+    }
+}

--- a/src/Esfa.Vacancy.UnitTests/CreateApprenticeship/Application/GivenACreateApprenticeshipRequestValidator/AndWageTypeUnwaged/WhenValidatingMinWage.cs
+++ b/src/Esfa.Vacancy.UnitTests/CreateApprenticeship/Application/GivenACreateApprenticeshipRequestValidator/AndWageTypeUnwaged/WhenValidatingMinWage.cs
@@ -1,0 +1,56 @@
+﻿using System.Linq;
+using System.Threading.Tasks;
+using Esfa.Vacancy.Application.Commands.CreateApprenticeship;
+using Esfa.Vacancy.Application.Commands.CreateApprenticeship.Validators;
+using Esfa.Vacancy.Domain.Validation;
+using FluentAssertions;
+using NUnit.Framework;
+using Ploeh.AutoFixture;
+
+namespace Esfa.Vacancy.UnitTests.CreateApprenticeship.Application.GivenACreateApprenticeshipRequestValidator.AndWageTypeUnwaged
+{
+    [TestFixture]
+    public class WhenValidatingMinWage : CreateApprenticeshipRequestValidatorBase
+    {
+        [Test]
+        public async Task AndHasValueThenIsInvalid()
+        {
+            var fixture = new Fixture();
+            var request = new CreateApprenticeshipRequest
+            {
+                WageType = WageType.Unwaged,
+                MinWage = fixture.Create<decimal>()
+            };
+
+            var context = GetValidationContextForProperty(request, req => req.MinWage);
+
+            var validator = fixture.Create<CreateApprenticeshipRequestValidator>();
+
+            var result = await validator.ValidateAsync(context);
+
+            result.IsValid.Should().Be(false);
+            result.Errors.First().ErrorCode
+                .Should().Be(ErrorCodes.CreateApprenticeship.MinWage);
+            result.Errors.First().ErrorMessage
+                .Should().Be("'Min Wage' must be empty.");
+        }
+
+        [Test]
+        public async Task AndNoValueThenIsValid()
+        {
+            var fixture = new Fixture();
+            var request = new CreateApprenticeshipRequest
+            {
+                WageType = WageType.Unwaged
+            };
+
+            var context = GetValidationContextForProperty(request, req => req.MinWage);
+
+            var validator = fixture.Create<CreateApprenticeshipRequestValidator>();
+
+            var result = await validator.ValidateAsync(context);
+
+            result.IsValid.Should().Be(true);
+        }
+    }
+}

--- a/src/Esfa.Vacancy.UnitTests/CreateApprenticeship/Application/GivenACreateApprenticeshipRequestValidator/AndWageTypeUnwaged/WhenValidatingWageTypeReason.cs
+++ b/src/Esfa.Vacancy.UnitTests/CreateApprenticeship/Application/GivenACreateApprenticeshipRequestValidator/AndWageTypeUnwaged/WhenValidatingWageTypeReason.cs
@@ -13,7 +13,7 @@ namespace Esfa.Vacancy.UnitTests.CreateApprenticeship.Application.GivenACreateAp
     public class WhenValidatingWageTypeReason : CreateApprenticeshipRequestValidatorBase
     {
         [Test]
-        public async Task AndHasValueThenIsInvalid()
+        public async Task AndNoValueThenIsInvalid()
         {
             var fixture = new Fixture();
             var request = new CreateApprenticeshipRequest
@@ -31,11 +31,34 @@ namespace Esfa.Vacancy.UnitTests.CreateApprenticeship.Application.GivenACreateAp
             result.Errors.First().ErrorCode
                 .Should().Be(ErrorCodes.CreateApprenticeship.WageTypeReason);
             result.Errors.First().ErrorMessage
-                .Should().Be("'Wage Type Reason' must not be empty.");
+                .Should().Be("'Wage Type Reason' should not be empty.");
         }
 
         [Test]
-        public async Task AndNoValueThenIsValid()
+        public async Task AndEmptyStringValueThenIsInvalid()
+        {
+            var fixture = new Fixture();
+            var request = new CreateApprenticeshipRequest
+            {
+                WageType = WageType.Unwaged,
+                WageTypeReason = ""
+            };
+
+            var context = GetValidationContextForProperty(request, req => req.WageTypeReason);
+
+            var validator = fixture.Create<CreateApprenticeshipRequestValidator>();
+
+            var result = await validator.ValidateAsync(context);
+
+            result.IsValid.Should().Be(false);
+            result.Errors.First().ErrorCode
+                .Should().Be(ErrorCodes.CreateApprenticeship.WageTypeReason);
+            result.Errors.First().ErrorMessage
+                .Should().Be("'Wage Type Reason' should not be empty.");
+        }
+
+        [Test]
+        public async Task AndHasValueThenIsValid()
         {
             var fixture = new Fixture();
             var request = new CreateApprenticeshipRequest

--- a/src/Esfa.Vacancy.UnitTests/CreateApprenticeship/Application/GivenACreateApprenticeshipRequestValidator/AndWageTypeUnwaged/WhenValidatingWageTypeReason.cs
+++ b/src/Esfa.Vacancy.UnitTests/CreateApprenticeship/Application/GivenACreateApprenticeshipRequestValidator/AndWageTypeUnwaged/WhenValidatingWageTypeReason.cs
@@ -1,0 +1,56 @@
+﻿using System.Linq;
+using System.Threading.Tasks;
+using Esfa.Vacancy.Application.Commands.CreateApprenticeship;
+using Esfa.Vacancy.Application.Commands.CreateApprenticeship.Validators;
+using Esfa.Vacancy.Domain.Validation;
+using FluentAssertions;
+using NUnit.Framework;
+using Ploeh.AutoFixture;
+
+namespace Esfa.Vacancy.UnitTests.CreateApprenticeship.Application.GivenACreateApprenticeshipRequestValidator.AndWageTypeUnwaged
+{
+    [TestFixture]
+    public class WhenValidatingWageTypeReason : CreateApprenticeshipRequestValidatorBase
+    {
+        [Test]
+        public async Task AndHasValueThenIsInvalid()
+        {
+            var fixture = new Fixture();
+            var request = new CreateApprenticeshipRequest
+            {
+                WageType = WageType.Unwaged
+            };
+
+            var context = GetValidationContextForProperty(request, req => req.WageTypeReason);
+
+            var validator = fixture.Create<CreateApprenticeshipRequestValidator>();
+
+            var result = await validator.ValidateAsync(context);
+
+            result.IsValid.Should().Be(false);
+            result.Errors.First().ErrorCode
+                .Should().Be(ErrorCodes.CreateApprenticeship.WageTypeReason);
+            result.Errors.First().ErrorMessage
+                .Should().Be("'Wage Type Reason' must not be empty.");
+        }
+
+        [Test]
+        public async Task AndNoValueThenIsValid()
+        {
+            var fixture = new Fixture();
+            var request = new CreateApprenticeshipRequest
+            {
+                WageType = WageType.Unwaged,
+                WageTypeReason = fixture.Create<string>()
+            };
+
+            var context = GetValidationContextForProperty(request, req => req.WageTypeReason);
+
+            var validator = fixture.Create<CreateApprenticeshipRequestValidator>();
+
+            var result = await validator.ValidateAsync(context);
+
+            result.IsValid.Should().Be(true);
+        }
+    }
+}

--- a/src/Esfa.Vacancy.UnitTests/CreateApprenticeship/Application/GivenACreateApprenticeshipRequestValidator/WhenValidatingWageTypeReason.cs
+++ b/src/Esfa.Vacancy.UnitTests/CreateApprenticeship/Application/GivenACreateApprenticeshipRequestValidator/WhenValidatingWageTypeReason.cs
@@ -1,0 +1,64 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Esfa.Vacancy.Application.Commands.CreateApprenticeship;
+using Esfa.Vacancy.Application.Commands.CreateApprenticeship.Validators;
+using Esfa.Vacancy.Domain.Validation;
+using FluentAssertions;
+using NUnit.Framework;
+using Ploeh.AutoFixture;
+
+namespace Esfa.Vacancy.UnitTests.CreateApprenticeship.Application.GivenACreateApprenticeshipRequestValidator
+{
+    [TestFixture]
+    public class WhenValidatingWageTypeReason : CreateApprenticeshipRequestValidatorBase
+    {
+        private static readonly string WageTypeReasonLength240 = new string('a', 240);
+        private static readonly string WageTypeReasonLength241 = new string('a', 241);
+        private static readonly string WageTypeReasonHtml = "<p>I like <strong onmouseover='prompt(\"you've been hax0rd\");'>html</strong></p>";
+
+        private static List<TestCaseData> TestCases => new List<TestCaseData>
+        {
+            new TestCaseData(null, true, null, null)
+                .SetName("And is null Then is valid"),
+            new TestCaseData("", true, null, null)
+                .SetName("And is empty string Then is valid"),
+            new TestCaseData(WageTypeReasonLength241, false,
+                    ErrorCodes.CreateApprenticeship.WageTypeReason,
+                    $"'Wage Type Reason' must be less than 241 characters. You entered {WageTypeReasonLength241.Length} characters.")
+                .SetName("And has length 241 Then is invalid"),
+            new TestCaseData(WageTypeReasonHtml, false,
+                    ErrorCodes.CreateApprenticeship.WageTypeReason,
+                    "'Wage Type Reason' can't contain invalid characters")
+                .SetName("And has html Then is invalid"),
+            new TestCaseData(WageTypeReasonLength240, true, null, null)
+                .SetName("And has length 240 Then is valid")
+        };
+
+        [TestCaseSource(nameof(TestCases))]
+        public async Task AndCallingValidate(string wageTypeReasonToValidate, bool expectedIsValid,
+            string expectedErrorCodes, string expectedErrorMessages)
+        {
+            var fixture = new Fixture();
+            var request = new CreateApprenticeshipRequest
+            {
+                WageTypeReason = wageTypeReasonToValidate
+            };
+
+            var context = GetValidationContextForProperty(request, req => req.WageTypeReason);
+
+            var validator = fixture.Create<CreateApprenticeshipRequestValidator>();
+
+            var result = await validator.ValidateAsync(context);
+
+            result.IsValid.Should().Be(expectedIsValid);
+            if (!expectedIsValid)
+            {
+                result.Errors.First().ErrorCode
+                    .Should().Be(expectedErrorCodes);
+                result.Errors.First().ErrorMessage
+                    .Should().Be(expectedErrorMessages);
+            }
+        }
+    }
+}

--- a/src/Esfa.Vacancy.UnitTests/Esfa.Vacancy.UnitTests.csproj
+++ b/src/Esfa.Vacancy.UnitTests/Esfa.Vacancy.UnitTests.csproj
@@ -162,6 +162,7 @@
     <Compile Include="CreateApprenticeship\Application\GivenACreateApprenticeshipRequestValidator\WhenValidatingNumberOfPositions.cs" />
     <Compile Include="CreateApprenticeship\Application\GivenACreateApprenticeshipRequestValidator\WhenValidatingProviderSiteEdsUrn.cs" />
     <Compile Include="CreateApprenticeship\Application\GivenACreateApprenticeshipRequestValidator\WhenValidatingWageType.cs" />
+    <Compile Include="CreateApprenticeship\Application\GivenACreateApprenticeshipRequestValidator\WhenValidatingWageTypeReason.cs" />
     <Compile Include="CreateApprenticeship\Application\GivenACreateApprenticeshipRequestValidator\WhenValidatingWorkingWeek.cs" />
     <Compile Include="CreateApprenticeship\Application\GivenACreateApprenticeshipRequestValidator\WhenValidatingLocationType.cs" />
     <Compile Include="CreateApprenticeship\Application\GivenACreateApprenticeshipRequestValidator\WhenValidatingLongDescription.cs" />

--- a/src/Esfa.Vacancy.UnitTests/Esfa.Vacancy.UnitTests.csproj
+++ b/src/Esfa.Vacancy.UnitTests/Esfa.Vacancy.UnitTests.csproj
@@ -130,6 +130,7 @@
     <Compile Include="CreateApprenticeship\Application\GivenACreateApprenticeshipRequestValidator\WhenValidatingLocation\AndLocationTypeIsInvalid.cs" />
     <Compile Include="CreateApprenticeship\Application\GivenACreateApprenticeshipRequestValidator\WhenValidatingLocation\AndLocationTypeIsNationwide.cs" />
     <Compile Include="CreateApprenticeship\Application\GivenACreateApprenticeshipRequestValidator\WhenValidatingLocation\AndLocationTypeOfOther\WhenValidatingAddressLine1.cs" />
+    <Compile Include="CreateApprenticeship\Application\GivenACreateApprenticeshipRequestValidator\AndWageTypeApprenticeshipMinimumWage\WhenValidatingWageTypeReason.cs" />
     <Compile Include="CreateApprenticeship\Application\GivenACreateApprenticeshipRequestValidator\WhenValidatingLocation\AndLocationTypeOfOther\WhenValidatingAddressLine3.cs" />
     <Compile Include="CreateApprenticeship\Application\GivenACreateApprenticeshipRequestValidator\WhenValidatingLocation\AndLocationTypeOfOther\WhenValidatingAddressLine4.cs" />
     <Compile Include="CreateApprenticeship\Application\GivenACreateApprenticeshipRequestValidator\WhenValidatingLocation\AndLocationTypeOfOther\WhenValidatingAddressLine5.cs" />
@@ -139,6 +140,7 @@
     <Compile Include="CreateApprenticeship\Application\GivenACreateApprenticeshipRequestValidator\AndWageTypeApprenticeshipMinimumWage\WhenValidatingMinWage.cs" />
     <Compile Include="CreateApprenticeship\Application\GivenACreateApprenticeshipRequestValidator\AndWageTypeNationalMinimumWage\WhenValidatingMaxWage.cs" />
     <Compile Include="CreateApprenticeship\Application\GivenACreateApprenticeshipRequestValidator\AndWageTypeNationalMinimumWage\WhenValidatingMinWage.cs" />
+    <Compile Include="CreateApprenticeship\Application\GivenACreateApprenticeshipRequestValidator\AndWageTypeNationalMinimumWage\WhenValidatingWageTypeReason.cs" />
     <Compile Include="CreateApprenticeship\Application\GivenACreateApprenticeshipRequestValidator\CreateApprenticeshipRequestValidatorBase.cs" />
     <Compile Include="CreateApprenticeship\Application\GivenACreateApprenticeshipRequestValidator\WhenValidatingApplicationClosingDate.cs" />
     <Compile Include="CreateApprenticeship\Application\GivenACreateApprenticeshipRequestValidator\WhenValidatingEmployerEdsUrn.cs" />

--- a/src/Esfa.Vacancy.UnitTests/Esfa.Vacancy.UnitTests.csproj
+++ b/src/Esfa.Vacancy.UnitTests/Esfa.Vacancy.UnitTests.csproj
@@ -147,6 +147,9 @@
     <Compile Include="CreateApprenticeship\Application\GivenACreateApprenticeshipRequestValidator\AndWageTypeCompetitiveSalary\WhenValidatingMaxWage.cs" />
     <Compile Include="CreateApprenticeship\Application\GivenACreateApprenticeshipRequestValidator\AndWageTypeCompetitiveSalary\WhenValidatingMinWage.cs" />
     <Compile Include="CreateApprenticeship\Application\GivenACreateApprenticeshipRequestValidator\AndWageTypeCompetitiveSalary\WhenValidatingWageTypeReason.cs" />
+    <Compile Include="CreateApprenticeship\Application\GivenACreateApprenticeshipRequestValidator\AndWageTypeToBeSpecified\WhenValidatingMaxWage.cs" />
+    <Compile Include="CreateApprenticeship\Application\GivenACreateApprenticeshipRequestValidator\AndWageTypeToBeSpecified\WhenValidatingMinWage.cs" />
+    <Compile Include="CreateApprenticeship\Application\GivenACreateApprenticeshipRequestValidator\AndWageTypeToBeSpecified\WhenValidatingWageTypeReason.cs" />
     <Compile Include="CreateApprenticeship\Application\GivenACreateApprenticeshipRequestValidator\AndWageTypeUnwaged\WhenValidatingMaxWage.cs" />
     <Compile Include="CreateApprenticeship\Application\GivenACreateApprenticeshipRequestValidator\AndWageTypeUnwaged\WhenValidatingMinWage.cs" />
     <Compile Include="CreateApprenticeship\Application\GivenACreateApprenticeshipRequestValidator\AndWageTypeUnwaged\WhenValidatingWageTypeReason.cs" />

--- a/src/Esfa.Vacancy.UnitTests/Esfa.Vacancy.UnitTests.csproj
+++ b/src/Esfa.Vacancy.UnitTests/Esfa.Vacancy.UnitTests.csproj
@@ -138,6 +138,9 @@
     <Compile Include="CreateApprenticeship\Application\GivenACreateApprenticeshipRequestValidator\WhenValidatingLocation\AndLocationTypeOfOther\WhenValidatingTown.cs" />
     <Compile Include="CreateApprenticeship\Application\GivenACreateApprenticeshipRequestValidator\AndWageTypeApprenticeshipMinimumWage\WhenValidatingMaxWage.cs" />
     <Compile Include="CreateApprenticeship\Application\GivenACreateApprenticeshipRequestValidator\AndWageTypeApprenticeshipMinimumWage\WhenValidatingMinWage.cs" />
+    <Compile Include="CreateApprenticeship\Application\GivenACreateApprenticeshipRequestValidator\AndWageTypeCustom\WhenValidatingMaxWage.cs" />
+    <Compile Include="CreateApprenticeship\Application\GivenACreateApprenticeshipRequestValidator\AndWageTypeCustom\WhenValidatingMinWage.cs" />
+    <Compile Include="CreateApprenticeship\Application\GivenACreateApprenticeshipRequestValidator\AndWageTypeCustom\WhenValidatingWageTypeReason.cs" />
     <Compile Include="CreateApprenticeship\Application\GivenACreateApprenticeshipRequestValidator\AndWageTypeNationalMinimumWage\WhenValidatingMaxWage.cs" />
     <Compile Include="CreateApprenticeship\Application\GivenACreateApprenticeshipRequestValidator\AndWageTypeNationalMinimumWage\WhenValidatingMinWage.cs" />
     <Compile Include="CreateApprenticeship\Application\GivenACreateApprenticeshipRequestValidator\AndWageTypeNationalMinimumWage\WhenValidatingWageTypeReason.cs" />

--- a/src/Esfa.Vacancy.UnitTests/Esfa.Vacancy.UnitTests.csproj
+++ b/src/Esfa.Vacancy.UnitTests/Esfa.Vacancy.UnitTests.csproj
@@ -144,6 +144,9 @@
     <Compile Include="CreateApprenticeship\Application\GivenACreateApprenticeshipRequestValidator\AndWageTypeNationalMinimumWage\WhenValidatingMaxWage.cs" />
     <Compile Include="CreateApprenticeship\Application\GivenACreateApprenticeshipRequestValidator\AndWageTypeNationalMinimumWage\WhenValidatingMinWage.cs" />
     <Compile Include="CreateApprenticeship\Application\GivenACreateApprenticeshipRequestValidator\AndWageTypeNationalMinimumWage\WhenValidatingWageTypeReason.cs" />
+    <Compile Include="CreateApprenticeship\Application\GivenACreateApprenticeshipRequestValidator\AndWageTypeUnwaged\WhenValidatingMaxWage.cs" />
+    <Compile Include="CreateApprenticeship\Application\GivenACreateApprenticeshipRequestValidator\AndWageTypeUnwaged\WhenValidatingMinWage.cs" />
+    <Compile Include="CreateApprenticeship\Application\GivenACreateApprenticeshipRequestValidator\AndWageTypeUnwaged\WhenValidatingWageTypeReason.cs" />
     <Compile Include="CreateApprenticeship\Application\GivenACreateApprenticeshipRequestValidator\CreateApprenticeshipRequestValidatorBase.cs" />
     <Compile Include="CreateApprenticeship\Application\GivenACreateApprenticeshipRequestValidator\WhenValidatingApplicationClosingDate.cs" />
     <Compile Include="CreateApprenticeship\Application\GivenACreateApprenticeshipRequestValidator\WhenValidatingEmployerEdsUrn.cs" />

--- a/src/Esfa.Vacancy.UnitTests/Esfa.Vacancy.UnitTests.csproj
+++ b/src/Esfa.Vacancy.UnitTests/Esfa.Vacancy.UnitTests.csproj
@@ -144,6 +144,9 @@
     <Compile Include="CreateApprenticeship\Application\GivenACreateApprenticeshipRequestValidator\AndWageTypeNationalMinimumWage\WhenValidatingMaxWage.cs" />
     <Compile Include="CreateApprenticeship\Application\GivenACreateApprenticeshipRequestValidator\AndWageTypeNationalMinimumWage\WhenValidatingMinWage.cs" />
     <Compile Include="CreateApprenticeship\Application\GivenACreateApprenticeshipRequestValidator\AndWageTypeNationalMinimumWage\WhenValidatingWageTypeReason.cs" />
+    <Compile Include="CreateApprenticeship\Application\GivenACreateApprenticeshipRequestValidator\AndWageTypeCompetitiveSalary\WhenValidatingMaxWage.cs" />
+    <Compile Include="CreateApprenticeship\Application\GivenACreateApprenticeshipRequestValidator\AndWageTypeCompetitiveSalary\WhenValidatingMinWage.cs" />
+    <Compile Include="CreateApprenticeship\Application\GivenACreateApprenticeshipRequestValidator\AndWageTypeCompetitiveSalary\WhenValidatingWageTypeReason.cs" />
     <Compile Include="CreateApprenticeship\Application\GivenACreateApprenticeshipRequestValidator\AndWageTypeUnwaged\WhenValidatingMaxWage.cs" />
     <Compile Include="CreateApprenticeship\Application\GivenACreateApprenticeshipRequestValidator\AndWageTypeUnwaged\WhenValidatingMinWage.cs" />
     <Compile Include="CreateApprenticeship\Application\GivenACreateApprenticeshipRequestValidator\AndWageTypeUnwaged\WhenValidatingWageTypeReason.cs" />


### PR DESCRIPTION
### Known Issues:

- will show validation error for invalid chars for `WageTypeReason` as well as a "not allowed" error if not allowed (e.g. for `WageType.Custom`). That is, the first message seems redundant.