### PR TITLE
RA-1584 sandbox feature toggle

### DIFF
--- a/src/Esfa.Vacancy.Application/Commands/CreateApprenticeship/CreateApprenticeshipCommandHandler.cs
+++ b/src/Esfa.Vacancy.Application/Commands/CreateApprenticeship/CreateApprenticeshipCommandHandler.cs
@@ -1,7 +1,7 @@
 ﻿using System.Threading.Tasks;
 using Esfa.Vacancy.Application.Exceptions;
+using Esfa.Vacancy.Domain.Constants;
 using Esfa.Vacancy.Domain.Interfaces;
-using Esfa.Vacancy.Domain.Repositories;
 using Esfa.Vacancy.Domain.Validation;
 using FluentValidation;
 using MediatR;
@@ -16,19 +16,22 @@ namespace Esfa.Vacancy.Application.Commands.CreateApprenticeship
         private readonly ICreateApprenticeshipParametersMapper _parametersMapper;
         private readonly ILog _logger;
         private readonly IVacancyOwnerService _vacancyOwnerService;
+        private readonly IProvideSettings _provideSettings;
 
         public CreateApprenticeshipCommandHandler(
             IValidator<CreateApprenticeshipRequest> validator,
             ICreateApprenticeshipService createApprenticeshipService,
             ICreateApprenticeshipParametersMapper parametersMapper,
             ILog logger,
-            IVacancyOwnerService vacancyOwnerService)
+            IVacancyOwnerService vacancyOwnerService,
+            IProvideSettings provideSettings)
         {
             _validator = validator;
             _createApprenticehipService = createApprenticeshipService;
             _parametersMapper = parametersMapper;
             _logger = logger;
             _vacancyOwnerService = vacancyOwnerService;
+            _provideSettings = provideSettings;
         }
 
         public async Task<CreateApprenticeshipResponse> Handle(CreateApprenticeshipRequest message)
@@ -47,6 +50,15 @@ namespace Esfa.Vacancy.Application.Commands.CreateApprenticeship
                 throw new UnauthorisedException(ErrorMessages.CreateApprenticeship.MissingProviderSiteEmployerLink);
 
             var parameters = _parametersMapper.MapFromRequest(message, employerInformation);
+
+            var isRunningUnderSandboxEnvironment =
+                _provideSettings.GetNullableSetting(ApplicationSettingKeys.IsSandboxEnvironment);
+
+            if (string.IsNullOrWhiteSpace(isRunningUnderSandboxEnvironment) == false)
+            {
+                //If sandbox environment then don't persist the vacancy
+                return new CreateApprenticeshipResponse();
+            }
 
             var referenceNumber = await _createApprenticehipService.CreateApprenticeshipAsync(parameters);
 

--- a/src/Esfa.Vacancy.Domain/Constants/ApplicationSettingKeys.cs
+++ b/src/Esfa.Vacancy.Domain/Constants/ApplicationSettingKeys.cs
@@ -1,6 +1,6 @@
-﻿namespace Esfa.Vacancy.Infrastructure.Settings
+﻿namespace Esfa.Vacancy.Domain.Constants
 {
-    public static class ApplicationSettingKeyConstants
+    public static class ApplicationSettingKeys
     {
         public const string AvmsPlusDatabaseConnectionStringKey = "AvmsPlusDatabaseConnectionString";
         public const string DasApprenticeshipInfoApiBaseUrlKey = "ApprenticeshipInfoApiBaseUrl";

--- a/src/Esfa.Vacancy.Domain/Constants/ApplicationSettingKeys.cs
+++ b/src/Esfa.Vacancy.Domain/Constants/ApplicationSettingKeys.cs
@@ -9,5 +9,6 @@
         public const string VacancySearchUrlKey = "VacancySearchUrl";
         public const string ApprenticeshipIndexAliasKey = "ApprenticeshipIndexAlias";
         public const string CacheConnectionString = "CacheConnectionString";
+        public const string IsSandboxEnvironment = "IsSandboxEnvironment";
     }
 }

--- a/src/Esfa.Vacancy.Domain/Esfa.Vacancy.Domain.csproj
+++ b/src/Esfa.Vacancy.Domain/Esfa.Vacancy.Domain.csproj
@@ -38,6 +38,7 @@
     <Compile Include="..\SharedAssemblyInfo.cs">
       <Link>Properties\SharedAssemblyInfo.cs</Link>
     </Compile>
+    <Compile Include="Constants\ApplicationSettingKeys.cs" />
     <Compile Include="Entities\Address.cs" />
     <Compile Include="Entities\ApprenticeshipSummary.cs" />
     <Compile Include="Entities\CreateApprenticeshipParameters.cs" />

--- a/src/Esfa.Vacancy.Domain/Esfa.Vacancy.Domain.csproj
+++ b/src/Esfa.Vacancy.Domain/Esfa.Vacancy.Domain.csproj
@@ -55,6 +55,7 @@
     <Compile Include="Interfaces\ICacheService.cs" />
     <Compile Include="Interfaces\IGetApprenticeshipService.cs" />
     <Compile Include="Interfaces\IGetTraineeshipService.cs" />
+    <Compile Include="Interfaces\IProvideSettings.cs" />
     <Compile Include="Interfaces\IVacancyOwnerService.cs" />
     <Compile Include="Interfaces\ICreateApprenticeshipService.cs" />
     <Compile Include="Validation\ErrorCodes.cs" />

--- a/src/Esfa.Vacancy.Domain/Interfaces/IProvideSettings.cs
+++ b/src/Esfa.Vacancy.Domain/Interfaces/IProvideSettings.cs
@@ -1,4 +1,4 @@
-﻿namespace Esfa.Vacancy.Infrastructure.Settings
+﻿namespace Esfa.Vacancy.Domain.Interfaces
 {
     public interface IProvideSettings
     {

--- a/src/Esfa.Vacancy.Infrastructure/Caching/AzureRedisCacheService.cs
+++ b/src/Esfa.Vacancy.Infrastructure/Caching/AzureRedisCacheService.cs
@@ -1,7 +1,7 @@
 ﻿using System;
 using System.Threading.Tasks;
+using Esfa.Vacancy.Domain.Constants;
 using Esfa.Vacancy.Domain.Interfaces;
-using Esfa.Vacancy.Infrastructure.Settings;
 using Newtonsoft.Json;
 using SFA.DAS.NLog.Logger;
 using StackExchange.Redis;
@@ -17,7 +17,7 @@ namespace Esfa.Vacancy.Infrastructure.Caching
         public AzureRedisCacheService(IProvideSettings settings, ILog logger)
         {
             _logger = logger;
-            var cacheConnectionString = settings.GetSetting(ApplicationSettingKeyConstants.CacheConnectionString);
+            var cacheConnectionString = settings.GetSetting(ApplicationSettingKeys.CacheConnectionString);
             _lazyConnection = new Lazy<ConnectionMultiplexer>(() => ConnectionMultiplexer.Connect(cacheConnectionString));
         }
 

--- a/src/Esfa.Vacancy.Infrastructure/Esfa.Vacancy.Infrastructure.csproj
+++ b/src/Esfa.Vacancy.Infrastructure/Esfa.Vacancy.Infrastructure.csproj
@@ -133,7 +133,6 @@
     <Compile Include="Services\TrainingDetailService.cs" />
     <Compile Include="Services\VacancyOwnerService.cs" />
     <Compile Include="Settings\AppConfigSettingsProvider.cs" />
-    <Compile Include="Settings\ApplicationSettingKeyConstants.cs" />
     <Compile Include="Settings\ApplicationSettings.cs" />
     <Compile Include="Settings\MachineSettings.cs" />
     <Compile Include="PollyRetryPolicies.cs" />

--- a/src/Esfa.Vacancy.Infrastructure/Esfa.Vacancy.Infrastructure.csproj
+++ b/src/Esfa.Vacancy.Infrastructure/Esfa.Vacancy.Infrastructure.csproj
@@ -135,7 +135,6 @@
     <Compile Include="Settings\AppConfigSettingsProvider.cs" />
     <Compile Include="Settings\ApplicationSettingKeyConstants.cs" />
     <Compile Include="Settings\ApplicationSettings.cs" />
-    <Compile Include="Settings\IProvideSettings.cs" />
     <Compile Include="Settings\MachineSettings.cs" />
     <Compile Include="PollyRetryPolicies.cs" />
   </ItemGroup>

--- a/src/Esfa.Vacancy.Infrastructure/Factories/ElasticClientFactory.cs
+++ b/src/Esfa.Vacancy.Infrastructure/Factories/ElasticClientFactory.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using Esfa.Vacancy.Domain.Interfaces;
 using Esfa.Vacancy.Infrastructure.Settings;
 using Nest;
 

--- a/src/Esfa.Vacancy.Infrastructure/Factories/ElasticClientFactory.cs
+++ b/src/Esfa.Vacancy.Infrastructure/Factories/ElasticClientFactory.cs
@@ -1,6 +1,6 @@
 ﻿using System;
+using Esfa.Vacancy.Domain.Constants;
 using Esfa.Vacancy.Domain.Interfaces;
-using Esfa.Vacancy.Infrastructure.Settings;
 using Nest;
 
 namespace Esfa.Vacancy.Infrastructure.Factories
@@ -17,10 +17,10 @@ namespace Esfa.Vacancy.Infrastructure.Factories
 
         public IElasticClient GetClient()
         {
-            var baseUri = _provideSettings.GetSetting(ApplicationSettingKeyConstants.VacancySearchUrlKey);
+            var baseUri = _provideSettings.GetSetting(ApplicationSettingKeys.VacancySearchUrlKey);
             var node = new Uri(baseUri);
             var settings = new ConnectionSettings(node);
-            
+
             settings.SetTimeout(ElasticClientTimeoutMilliseconds);
 
             return new ElasticClient(settings);

--- a/src/Esfa.Vacancy.Infrastructure/Factories/SqlDatabaseService.cs
+++ b/src/Esfa.Vacancy.Infrastructure/Factories/SqlDatabaseService.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Data.SqlClient;
 using System.Threading.Tasks;
+using Esfa.Vacancy.Domain.Interfaces;
 using Esfa.Vacancy.Infrastructure.Settings;
 using SFA.DAS.NLog.Logger;
 

--- a/src/Esfa.Vacancy.Infrastructure/Factories/SqlDatabaseService.cs
+++ b/src/Esfa.Vacancy.Infrastructure/Factories/SqlDatabaseService.cs
@@ -1,8 +1,8 @@
 ﻿using System;
 using System.Data.SqlClient;
 using System.Threading.Tasks;
+using Esfa.Vacancy.Domain.Constants;
 using Esfa.Vacancy.Domain.Interfaces;
-using Esfa.Vacancy.Infrastructure.Settings;
 using SFA.DAS.NLog.Logger;
 
 namespace Esfa.Vacancy.Infrastructure.Factories
@@ -21,7 +21,7 @@ namespace Esfa.Vacancy.Infrastructure.Factories
         public SqlConnection GetConnection()
         {
             var connectionString =
-                _settings.GetSetting(ApplicationSettingKeyConstants.AvmsPlusDatabaseConnectionStringKey);
+                _settings.GetSetting(ApplicationSettingKeys.AvmsPlusDatabaseConnectionStringKey);
 
             return new SqlConnection(connectionString);
         }

--- a/src/Esfa.Vacancy.Infrastructure/Repositories/FrameworkCodeRepository.cs
+++ b/src/Esfa.Vacancy.Infrastructure/Repositories/FrameworkCodeRepository.cs
@@ -4,9 +4,9 @@ using System.Data.SqlClient;
 using System.Linq;
 using System.Threading.Tasks;
 using Dapper;
+using Esfa.Vacancy.Domain.Constants;
 using Esfa.Vacancy.Domain.Interfaces;
 using Esfa.Vacancy.Domain.Repositories;
-using Esfa.Vacancy.Infrastructure.Settings;
 using SFA.DAS.NLog.Logger;
 
 namespace Esfa.Vacancy.Infrastructure.Repositories
@@ -17,7 +17,7 @@ namespace Esfa.Vacancy.Infrastructure.Repositories
         private readonly ILog _logger;
 
         private const string GetActiveFrameworkCodesSqlSproc = "[VACANCY_API].[GetActiveFrameworkCodes]";
-        
+
         public FrameworkCodeRepository(IProvideSettings settings, ILog logger)
         {
             _settings = settings;
@@ -38,7 +38,7 @@ namespace Esfa.Vacancy.Infrastructure.Repositories
         {
             _logger.Info("Querying AVMS database for Framework Codes");
             var connectionString =
-                _settings.GetSetting(ApplicationSettingKeyConstants.AvmsPlusDatabaseConnectionStringKey);
+                _settings.GetSetting(ApplicationSettingKeys.AvmsPlusDatabaseConnectionStringKey);
 
             using (var sqlConn = new SqlConnection(connectionString))
             {

--- a/src/Esfa.Vacancy.Infrastructure/Repositories/FrameworkCodeRepository.cs
+++ b/src/Esfa.Vacancy.Infrastructure/Repositories/FrameworkCodeRepository.cs
@@ -4,6 +4,7 @@ using System.Data.SqlClient;
 using System.Linq;
 using System.Threading.Tasks;
 using Dapper;
+using Esfa.Vacancy.Domain.Interfaces;
 using Esfa.Vacancy.Domain.Repositories;
 using Esfa.Vacancy.Infrastructure.Settings;
 using SFA.DAS.NLog.Logger;

--- a/src/Esfa.Vacancy.Infrastructure/Repositories/StandardRepository.cs
+++ b/src/Esfa.Vacancy.Infrastructure/Repositories/StandardRepository.cs
@@ -4,6 +4,7 @@ using System.Data.SqlClient;
 using System.Linq;
 using System.Threading.Tasks;
 using Dapper;
+using Esfa.Vacancy.Domain.Interfaces;
 using Esfa.Vacancy.Domain.Repositories;
 using Esfa.Vacancy.Infrastructure.Settings;
 using SFA.DAS.NLog.Logger;

--- a/src/Esfa.Vacancy.Infrastructure/Repositories/StandardRepository.cs
+++ b/src/Esfa.Vacancy.Infrastructure/Repositories/StandardRepository.cs
@@ -4,9 +4,9 @@ using System.Data.SqlClient;
 using System.Linq;
 using System.Threading.Tasks;
 using Dapper;
+using Esfa.Vacancy.Domain.Constants;
 using Esfa.Vacancy.Domain.Interfaces;
 using Esfa.Vacancy.Domain.Repositories;
-using Esfa.Vacancy.Infrastructure.Settings;
 using SFA.DAS.NLog.Logger;
 
 namespace Esfa.Vacancy.Infrastructure.Repositories
@@ -39,7 +39,7 @@ namespace Esfa.Vacancy.Infrastructure.Repositories
             _logger.Info("Querying AVMS database for Standard Codes");
 
             var connectionString =
-                _provideSettings.GetSetting(ApplicationSettingKeyConstants.AvmsPlusDatabaseConnectionStringKey);
+                _provideSettings.GetSetting(ApplicationSettingKeys.AvmsPlusDatabaseConnectionStringKey);
 
             using (var sqlConn = new SqlConnection(connectionString))
             {

--- a/src/Esfa.Vacancy.Infrastructure/Services/ApprenticeshipSearchService.cs
+++ b/src/Esfa.Vacancy.Infrastructure/Services/ApprenticeshipSearchService.cs
@@ -5,6 +5,7 @@ using System.Threading.Tasks;
 using Esfa.Vacancy.Application.Interfaces;
 using Esfa.Vacancy.Application.Queries.SearchApprenticeshipVacancies;
 using Esfa.Vacancy.Domain.Entities;
+using Esfa.Vacancy.Domain.Interfaces;
 using Esfa.Vacancy.Infrastructure.Exceptions;
 using Esfa.Vacancy.Infrastructure.Settings;
 using Nest;

--- a/src/Esfa.Vacancy.Infrastructure/Services/ApprenticeshipSearchService.cs
+++ b/src/Esfa.Vacancy.Infrastructure/Services/ApprenticeshipSearchService.cs
@@ -4,10 +4,10 @@ using System.Net;
 using System.Threading.Tasks;
 using Esfa.Vacancy.Application.Interfaces;
 using Esfa.Vacancy.Application.Queries.SearchApprenticeshipVacancies;
+using Esfa.Vacancy.Domain.Constants;
 using Esfa.Vacancy.Domain.Entities;
 using Esfa.Vacancy.Domain.Interfaces;
 using Esfa.Vacancy.Infrastructure.Exceptions;
-using Esfa.Vacancy.Infrastructure.Settings;
 using Nest;
 using SFA.DAS.NLog.Logger;
 
@@ -42,7 +42,7 @@ namespace Esfa.Vacancy.Infrastructure.Services
         private async Task<SearchApprenticeshipVacanciesResponse> InternalSearchApprenticeshipVacanciesAsync(
             VacancySearchParameters parameters)
         {
-            var indexName = _provideSettings.GetSetting(ApplicationSettingKeyConstants.ApprenticeshipIndexAliasKey);
+            var indexName = _provideSettings.GetSetting(ApplicationSettingKeys.ApprenticeshipIndexAliasKey);
 
             ISearchResponse<ApprenticeshipSummary> esReponse;
 
@@ -58,7 +58,7 @@ namespace Esfa.Vacancy.Infrastructure.Services
                         .Take(parameters.PageSize)
                         .Query(query =>
                         {
-                            var container =  
+                            var container =
                                 (query.Terms(apprenticeship => apprenticeship.FrameworkLarsCode, parameters.FrameworkLarsCodes)
                                  || query.Terms(apprenticeship => apprenticeship.StandardLarsCode, parameters.StandardLarsCodes))
                                     && query.Match(m => m.OnField(apprenticeship => apprenticeship.VacancyLocationType).Query(parameters.LocationType))

--- a/src/Esfa.Vacancy.Infrastructure/Services/TrainingDetailService.cs
+++ b/src/Esfa.Vacancy.Infrastructure/Services/TrainingDetailService.cs
@@ -1,8 +1,8 @@
 ﻿using System.Threading.Tasks;
 using Esfa.Vacancy.Application.Interfaces;
+using Esfa.Vacancy.Domain.Constants;
 using Esfa.Vacancy.Domain.Entities;
 using Esfa.Vacancy.Domain.Interfaces;
-using Esfa.Vacancy.Infrastructure.Settings;
 using SFA.DAS.Apprenticeships.Api.Client;
 using SFA.DAS.Apprenticeships.Api.Types.Exceptions;
 using SFA.DAS.NLog.Logger;
@@ -18,7 +18,7 @@ namespace Esfa.Vacancy.Infrastructure.Services
         {
             _logger = logger;
             _dasApiBaseUrl =
-                provideSettings.GetSetting(ApplicationSettingKeyConstants.DasApprenticeshipInfoApiBaseUrlKey);
+                provideSettings.GetSetting(ApplicationSettingKeys.DasApprenticeshipInfoApiBaseUrlKey);
         }
 
         public async Task<Framework> GetFrameworkDetailsAsync(int code)

--- a/src/Esfa.Vacancy.Infrastructure/Services/TrainingDetailService.cs
+++ b/src/Esfa.Vacancy.Infrastructure/Services/TrainingDetailService.cs
@@ -1,6 +1,7 @@
 ﻿using System.Threading.Tasks;
 using Esfa.Vacancy.Application.Interfaces;
 using Esfa.Vacancy.Domain.Entities;
+using Esfa.Vacancy.Domain.Interfaces;
 using Esfa.Vacancy.Infrastructure.Settings;
 using SFA.DAS.Apprenticeships.Api.Client;
 using SFA.DAS.Apprenticeships.Api.Types.Exceptions;

--- a/src/Esfa.Vacancy.Infrastructure/Settings/AppConfigSettingsProvider.cs
+++ b/src/Esfa.Vacancy.Infrastructure/Settings/AppConfigSettingsProvider.cs
@@ -1,4 +1,5 @@
 ﻿using System.Configuration;
+using Esfa.Vacancy.Domain.Interfaces;
 using Microsoft.Azure;
 
 namespace Esfa.Vacancy.Infrastructure.Settings

--- a/src/Esfa.Vacancy.Infrastructure/Settings/ApplicationSettings.cs
+++ b/src/Esfa.Vacancy.Infrastructure/Settings/ApplicationSettings.cs
@@ -1,4 +1,6 @@
-﻿namespace Esfa.Vacancy.Infrastructure.Settings
+﻿using Esfa.Vacancy.Domain.Interfaces;
+
+namespace Esfa.Vacancy.Infrastructure.Settings
 {
     public sealed class ApplicationSettings
     {

--- a/src/Esfa.Vacancy.Infrastructure/Settings/MachineSettings.cs
+++ b/src/Esfa.Vacancy.Infrastructure/Settings/MachineSettings.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Globalization;
+using Esfa.Vacancy.Domain.Interfaces;
 
 namespace Esfa.Vacancy.Infrastructure.Settings
 {

--- a/src/Esfa.Vacancy.Register.Api/Mappings/ApprenticeshipMapper.cs
+++ b/src/Esfa.Vacancy.Register.Api/Mappings/ApprenticeshipMapper.cs
@@ -1,9 +1,9 @@
 ﻿using System.ComponentModel;
 using System.Globalization;
-using ApiTypes = Esfa.Vacancy.Api.Types;
+using Esfa.Vacancy.Domain.Constants;
 using Esfa.Vacancy.Domain.Entities;
 using Esfa.Vacancy.Domain.Interfaces;
-using Esfa.Vacancy.Infrastructure.Settings;
+using ApiTypes = Esfa.Vacancy.Api.Types;
 
 namespace Esfa.Vacancy.Register.Api.Mappings
 {
@@ -21,7 +21,7 @@ namespace Esfa.Vacancy.Register.Api.Mappings
 
         public ApiTypes.ApprenticeshipVacancy MapToApprenticeshipVacancy(ApprenticeshipVacancy apprenticeshipVacancy)
         {
-            var liveVacancyBaseUrl = _provideSettings.GetSetting(ApplicationSettingKeyConstants.LiveApprenticeshipVacancyBaseUrlKey);
+            var liveVacancyBaseUrl = _provideSettings.GetSetting(ApplicationSettingKeys.LiveApprenticeshipVacancyBaseUrlKey);
 
             var apprenticeship = new ApiTypes.ApprenticeshipVacancy
             {

--- a/src/Esfa.Vacancy.Register.Api/Mappings/ApprenticeshipMapper.cs
+++ b/src/Esfa.Vacancy.Register.Api/Mappings/ApprenticeshipMapper.cs
@@ -2,6 +2,7 @@
 using System.Globalization;
 using ApiTypes = Esfa.Vacancy.Api.Types;
 using Esfa.Vacancy.Domain.Entities;
+using Esfa.Vacancy.Domain.Interfaces;
 using Esfa.Vacancy.Infrastructure.Settings;
 
 namespace Esfa.Vacancy.Register.Api.Mappings

--- a/src/Esfa.Vacancy.Register.Api/Mappings/TraineeshipMapper.cs
+++ b/src/Esfa.Vacancy.Register.Api/Mappings/TraineeshipMapper.cs
@@ -1,4 +1,5 @@
-﻿using Esfa.Vacancy.Infrastructure.Settings;
+﻿using Esfa.Vacancy.Domain.Interfaces;
+using Esfa.Vacancy.Infrastructure.Settings;
 using TraineeshipVacancy = Esfa.Vacancy.Api.Types.TraineeshipVacancy;
 
 namespace Esfa.Vacancy.Register.Api.Mappings

--- a/src/Esfa.Vacancy.Register.Api/Mappings/TraineeshipMapper.cs
+++ b/src/Esfa.Vacancy.Register.Api/Mappings/TraineeshipMapper.cs
@@ -1,5 +1,5 @@
-﻿using Esfa.Vacancy.Domain.Interfaces;
-using Esfa.Vacancy.Infrastructure.Settings;
+﻿using Esfa.Vacancy.Domain.Constants;
+using Esfa.Vacancy.Domain.Interfaces;
 using TraineeshipVacancy = Esfa.Vacancy.Api.Types.TraineeshipVacancy;
 
 namespace Esfa.Vacancy.Register.Api.Mappings
@@ -17,7 +17,7 @@ namespace Esfa.Vacancy.Register.Api.Mappings
 
         public TraineeshipVacancy MapToTraineeshipVacancy(Domain.Entities.TraineeshipVacancy traineeshipVacancy)
         {
-            var liveVacancyBaseUrl = _provideSettings.GetSetting(ApplicationSettingKeyConstants.LiveTraineeshipVacancyBaseUrlKey);
+            var liveVacancyBaseUrl = _provideSettings.GetSetting(ApplicationSettingKeys.LiveTraineeshipVacancyBaseUrlKey);
 
             return new TraineeshipVacancy
             {

--- a/src/Esfa.Vacancy.Register.Api/Orchestrators/SearchApprenticeshipVacanciesOrchestrator.cs
+++ b/src/Esfa.Vacancy.Register.Api/Orchestrators/SearchApprenticeshipVacanciesOrchestrator.cs
@@ -4,6 +4,7 @@ using AutoMapper;
 using Esfa.Vacancy.Api.Core.Validation;
 using Esfa.Vacancy.Api.Types;
 using Esfa.Vacancy.Application.Queries.SearchApprenticeshipVacancies;
+using Esfa.Vacancy.Domain.Interfaces;
 using Esfa.Vacancy.Domain.Validation;
 using Esfa.Vacancy.Infrastructure.Settings;
 using MediatR;

--- a/src/Esfa.Vacancy.Register.Api/Orchestrators/SearchApprenticeshipVacanciesOrchestrator.cs
+++ b/src/Esfa.Vacancy.Register.Api/Orchestrators/SearchApprenticeshipVacanciesOrchestrator.cs
@@ -4,9 +4,9 @@ using AutoMapper;
 using Esfa.Vacancy.Api.Core.Validation;
 using Esfa.Vacancy.Api.Types;
 using Esfa.Vacancy.Application.Queries.SearchApprenticeshipVacancies;
+using Esfa.Vacancy.Domain.Constants;
 using Esfa.Vacancy.Domain.Interfaces;
 using Esfa.Vacancy.Domain.Validation;
-using Esfa.Vacancy.Infrastructure.Settings;
 using MediatR;
 
 namespace Esfa.Vacancy.Register.Api.Orchestrators
@@ -58,7 +58,7 @@ namespace Esfa.Vacancy.Register.Api.Orchestrators
 
         private string GetVacancyUrl(int reference)
         {
-            string url = _provideSettings.GetSetting(ApplicationSettingKeyConstants.LiveApprenticeshipVacancyBaseUrlKey);
+            string url = _provideSettings.GetSetting(ApplicationSettingKeys.LiveApprenticeshipVacancyBaseUrlKey);
             return url.EndsWith("/") ? $"{url}{reference}" : $"{url}/{reference}";
         }
     }

--- a/src/Esfa.Vacancy.UnitTests/Esfa.Vacancy.UnitTests.csproj
+++ b/src/Esfa.Vacancy.UnitTests/Esfa.Vacancy.UnitTests.csproj
@@ -119,6 +119,7 @@
     <Compile Include="CreateApprenticeship\Api\Mappings\GivenACreateApprenticeshipResponseMapper\WhenMappingVacancyReferenceNumber.cs" />
     <Compile Include="CreateApprenticeship\Api\Orchestrators\GivenACreateApprenticeshipOrchestrator\WhenCreatingAnApprenticeshipVacancy.cs" />
     <Compile Include="CreateApprenticeship\Application\GivenACreateApprenticeshipCommandHandler\WhenHandlingACommand.cs" />
+    <Compile Include="CreateApprenticeship\Application\GivenACreateApprenticeshipCommandHandler\WhenRunningUnderSandboxEnvironment.cs" />
     <Compile Include="CreateApprenticeship\Application\GivenACreateApprenticeshipParametersMapper\WhenMappingFromARequest.cs" />
     <Compile Include="CreateApprenticeship\Application\GivenACreateApprenticeshipParametersMapper\WhenMappingLocation\AndLocationTypeIsNationwide.cs" />
     <Compile Include="CreateApprenticeship\Application\GivenACreateApprenticeshipParametersMapper\WhenMappingLocation\AndLocationTypeIsEmployerLocation.cs" />

--- a/src/Esfa.Vacancy.UnitTests/GetApprenticeshipVacancy/Api/Mappings/GivenAnApprenticeshipMapper/WhenMappingIsNationWide.cs
+++ b/src/Esfa.Vacancy.UnitTests/GetApprenticeshipVacancy/Api/Mappings/GivenAnApprenticeshipMapper/WhenMappingIsNationWide.cs
@@ -1,4 +1,5 @@
 ﻿using Esfa.Vacancy.Domain.Entities;
+using Esfa.Vacancy.Domain.Interfaces;
 using Esfa.Vacancy.Infrastructure.Settings;
 using Esfa.Vacancy.Register.Api.Mappings;
 using FluentAssertions;

--- a/src/Esfa.Vacancy.UnitTests/GetApprenticeshipVacancy/Api/Mappings/GivenAnApprenticeshipMapper/WhenMappingLiveApprenticeshipTrainingDetails.cs
+++ b/src/Esfa.Vacancy.UnitTests/GetApprenticeshipVacancy/Api/Mappings/GivenAnApprenticeshipMapper/WhenMappingLiveApprenticeshipTrainingDetails.cs
@@ -1,4 +1,5 @@
 ﻿using Esfa.Vacancy.Domain.Entities;
+using Esfa.Vacancy.Domain.Interfaces;
 using Esfa.Vacancy.Infrastructure.Settings;
 using Esfa.Vacancy.Register.Api.Mappings;
 using Moq;

--- a/src/Esfa.Vacancy.UnitTests/GetApprenticeshipVacancy/Api/Mappings/GivenAnApprenticeshipMapper/WhenMappingLiveApprenticeshipWageUnit.cs
+++ b/src/Esfa.Vacancy.UnitTests/GetApprenticeshipVacancy/Api/Mappings/GivenAnApprenticeshipMapper/WhenMappingLiveApprenticeshipWageUnit.cs
@@ -1,6 +1,7 @@
 ﻿using System.ComponentModel;
 using ApiTypes = Esfa.Vacancy.Api.Types;
 using Esfa.Vacancy.Domain.Entities;
+using Esfa.Vacancy.Domain.Interfaces;
 using Esfa.Vacancy.Infrastructure.Settings;
 using Esfa.Vacancy.Register.Api.Mappings;
 using FluentAssertions;

--- a/src/Esfa.Vacancy.UnitTests/GetApprenticeshipVacancy/Api/Mappings/GivenAnApprenticeshipMapper/WhenMappingLiveApprenticeshipWithAmbiguousWage.cs
+++ b/src/Esfa.Vacancy.UnitTests/GetApprenticeshipVacancy/Api/Mappings/GivenAnApprenticeshipMapper/WhenMappingLiveApprenticeshipWithAmbiguousWage.cs
@@ -1,5 +1,6 @@
 ﻿using ApiTypes = Esfa.Vacancy.Api.Types;
 using Esfa.Vacancy.Domain.Entities;
+using Esfa.Vacancy.Domain.Interfaces;
 using Esfa.Vacancy.Infrastructure.Settings;
 using FluentAssertions;
 using Moq;

--- a/src/Esfa.Vacancy.UnitTests/GetApprenticeshipVacancy/Api/Mappings/GivenAnApprenticeshipMapper/WhenMappingLiveApprenticeshipWithApprenticeshipMinimumWageType.cs
+++ b/src/Esfa.Vacancy.UnitTests/GetApprenticeshipVacancy/Api/Mappings/GivenAnApprenticeshipMapper/WhenMappingLiveApprenticeshipWithApprenticeshipMinimumWageType.cs
@@ -1,5 +1,6 @@
 ﻿using ApiTypes = Esfa.Vacancy.Api.Types;
 using Esfa.Vacancy.Domain.Entities;
+using Esfa.Vacancy.Domain.Interfaces;
 using Esfa.Vacancy.Infrastructure.Settings;
 using FluentAssertions;
 using Moq;

--- a/src/Esfa.Vacancy.UnitTests/GetApprenticeshipVacancy/Api/Mappings/GivenAnApprenticeshipMapper/WhenMappingLiveApprenticeshipWithCustomRangeWageType.cs
+++ b/src/Esfa.Vacancy.UnitTests/GetApprenticeshipVacancy/Api/Mappings/GivenAnApprenticeshipMapper/WhenMappingLiveApprenticeshipWithCustomRangeWageType.cs
@@ -1,5 +1,6 @@
 ﻿using ApiTypes = Esfa.Vacancy.Api.Types;
 using Esfa.Vacancy.Domain.Entities;
+using Esfa.Vacancy.Domain.Interfaces;
 using Esfa.Vacancy.Infrastructure.Settings;
 using FluentAssertions;
 using Moq;

--- a/src/Esfa.Vacancy.UnitTests/GetApprenticeshipVacancy/Api/Mappings/GivenAnApprenticeshipMapper/WhenMappingLiveApprenticeshipWithCustomWageType.cs
+++ b/src/Esfa.Vacancy.UnitTests/GetApprenticeshipVacancy/Api/Mappings/GivenAnApprenticeshipMapper/WhenMappingLiveApprenticeshipWithCustomWageType.cs
@@ -1,5 +1,6 @@
 ﻿using ApiTypes = Esfa.Vacancy.Api.Types;
 using Esfa.Vacancy.Domain.Entities;
+using Esfa.Vacancy.Domain.Interfaces;
 using Esfa.Vacancy.Infrastructure.Settings;
 using FluentAssertions;
 using Moq;

--- a/src/Esfa.Vacancy.UnitTests/GetApprenticeshipVacancy/Api/Mappings/GivenAnApprenticeshipMapper/WhenMappingLiveApprenticeshipWithLegacyTextWageType.cs
+++ b/src/Esfa.Vacancy.UnitTests/GetApprenticeshipVacancy/Api/Mappings/GivenAnApprenticeshipMapper/WhenMappingLiveApprenticeshipWithLegacyTextWageType.cs
@@ -1,5 +1,6 @@
 ﻿using ApiTypes = Esfa.Vacancy.Api.Types;
 using Esfa.Vacancy.Domain.Entities;
+using Esfa.Vacancy.Domain.Interfaces;
 using Esfa.Vacancy.Infrastructure.Settings;
 using FluentAssertions;
 using Moq;

--- a/src/Esfa.Vacancy.UnitTests/GetApprenticeshipVacancy/Api/Mappings/GivenAnApprenticeshipMapper/WhenMappingLiveApprenticeshipWithLegacyWeeklyWageType.cs
+++ b/src/Esfa.Vacancy.UnitTests/GetApprenticeshipVacancy/Api/Mappings/GivenAnApprenticeshipMapper/WhenMappingLiveApprenticeshipWithLegacyWeeklyWageType.cs
@@ -1,5 +1,6 @@
 ﻿using ApiTypes = Esfa.Vacancy.Api.Types;
 using Esfa.Vacancy.Domain.Entities;
+using Esfa.Vacancy.Domain.Interfaces;
 using Esfa.Vacancy.Infrastructure.Settings;
 using FluentAssertions;
 using Moq;

--- a/src/Esfa.Vacancy.UnitTests/GetApprenticeshipVacancy/Api/Mappings/GivenAnApprenticeshipMapper/WhenMappingLiveApprenticeshipWithNationalMinimumWageType.cs
+++ b/src/Esfa.Vacancy.UnitTests/GetApprenticeshipVacancy/Api/Mappings/GivenAnApprenticeshipMapper/WhenMappingLiveApprenticeshipWithNationalMinimumWageType.cs
@@ -1,5 +1,6 @@
 ﻿using ApiTypes = Esfa.Vacancy.Api.Types;
 using Esfa.Vacancy.Domain.Entities;
+using Esfa.Vacancy.Domain.Interfaces;
 using Esfa.Vacancy.Infrastructure.Settings;
 using FluentAssertions;
 using Moq;

--- a/src/Esfa.Vacancy.UnitTests/GetApprenticeshipVacancy/Api/Orchestrators/GivenAGetApprenticeshipVacancyOrchestrator/WhenGettingLiveApprenticeship.cs
+++ b/src/Esfa.Vacancy.UnitTests/GetApprenticeshipVacancy/Api/Orchestrators/GivenAGetApprenticeshipVacancyOrchestrator/WhenGettingLiveApprenticeship.cs
@@ -4,6 +4,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using Esfa.Vacancy.Api.Core.Validation;
 using Esfa.Vacancy.Application.Queries.GetApprenticeshipVacancy;
+using Esfa.Vacancy.Domain.Interfaces;
 using Esfa.Vacancy.Domain.Validation;
 using Esfa.Vacancy.Infrastructure.Settings;
 using Esfa.Vacancy.Register.Api.Mappings;

--- a/src/Esfa.Vacancy.UnitTests/GetApprenticeshipVacancy/Api/Orchestrators/GivenAGetApprenticeshipVacancyOrchestrator/WhenGettingLiveApprenticeship.cs
+++ b/src/Esfa.Vacancy.UnitTests/GetApprenticeshipVacancy/Api/Orchestrators/GivenAGetApprenticeshipVacancyOrchestrator/WhenGettingLiveApprenticeship.cs
@@ -4,9 +4,9 @@ using System.Threading;
 using System.Threading.Tasks;
 using Esfa.Vacancy.Api.Core.Validation;
 using Esfa.Vacancy.Application.Queries.GetApprenticeshipVacancy;
+using Esfa.Vacancy.Domain.Constants;
 using Esfa.Vacancy.Domain.Interfaces;
 using Esfa.Vacancy.Domain.Validation;
-using Esfa.Vacancy.Infrastructure.Settings;
 using Esfa.Vacancy.Register.Api.Mappings;
 using Esfa.Vacancy.Register.Api.Orchestrators;
 using FluentAssertions;
@@ -148,7 +148,7 @@ namespace Esfa.Vacancy.UnitTests.GetApprenticeshipVacancy.Api.Orchestrators.Give
 
             var provideSettings = new Mock<IProvideSettings>();
             provideSettings
-                .Setup(p => p.GetSetting(ApplicationSettingKeyConstants.LiveApprenticeshipVacancyBaseUrlKey))
+                .Setup(p => p.GetSetting(ApplicationSettingKeys.LiveApprenticeshipVacancyBaseUrlKey))
                 .Returns(baseUrl);
 
             var response = new GetApprenticeshipVacancyResponse()

--- a/src/Esfa.Vacancy.UnitTests/GetTraineeshipVacancy/Api/Mappings/GivenTraineeshipMapper.cs
+++ b/src/Esfa.Vacancy.UnitTests/GetTraineeshipVacancy/Api/Mappings/GivenTraineeshipMapper.cs
@@ -1,4 +1,5 @@
 ﻿using Esfa.Vacancy.Domain.Entities;
+using Esfa.Vacancy.Domain.Interfaces;
 using Esfa.Vacancy.Infrastructure.Settings;
 using Esfa.Vacancy.Register.Api.Mappings;
 using FluentAssertions;

--- a/src/Esfa.Vacancy.UnitTests/GetTraineeshipVacancy/Api/Orchestrators/GivenAGetTraineeshipVacancyOrchestrator/WhenGettingLiveTraineeship.cs
+++ b/src/Esfa.Vacancy.UnitTests/GetTraineeshipVacancy/Api/Orchestrators/GivenAGetTraineeshipVacancyOrchestrator/WhenGettingLiveTraineeship.cs
@@ -4,9 +4,9 @@ using System.Threading;
 using System.Threading.Tasks;
 using Esfa.Vacancy.Api.Core.Validation;
 using Esfa.Vacancy.Application.Queries.GetTraineeshipVacancy;
+using Esfa.Vacancy.Domain.Constants;
 using Esfa.Vacancy.Domain.Interfaces;
 using Esfa.Vacancy.Domain.Validation;
-using Esfa.Vacancy.Infrastructure.Settings;
 using Esfa.Vacancy.Register.Api.Mappings;
 using Esfa.Vacancy.Register.Api.Orchestrators;
 using FluentAssertions;
@@ -146,7 +146,7 @@ namespace Esfa.Vacancy.UnitTests.GetTraineeshipVacancy.Api.Orchestrators.GivenAG
 
             var mockProvideSettings = new Mock<IProvideSettings>();
             mockProvideSettings
-                .Setup(p => p.GetSetting(ApplicationSettingKeyConstants.LiveTraineeshipVacancyBaseUrlKey))
+                .Setup(p => p.GetSetting(ApplicationSettingKeys.LiveTraineeshipVacancyBaseUrlKey))
                 .Returns(baseUrl);
 
             var response = new GetTraineeshipVacancyResponse

--- a/src/Esfa.Vacancy.UnitTests/GetTraineeshipVacancy/Api/Orchestrators/GivenAGetTraineeshipVacancyOrchestrator/WhenGettingLiveTraineeship.cs
+++ b/src/Esfa.Vacancy.UnitTests/GetTraineeshipVacancy/Api/Orchestrators/GivenAGetTraineeshipVacancyOrchestrator/WhenGettingLiveTraineeship.cs
@@ -4,6 +4,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using Esfa.Vacancy.Api.Core.Validation;
 using Esfa.Vacancy.Application.Queries.GetTraineeshipVacancy;
+using Esfa.Vacancy.Domain.Interfaces;
 using Esfa.Vacancy.Domain.Validation;
 using Esfa.Vacancy.Infrastructure.Settings;
 using Esfa.Vacancy.Register.Api.Mappings;

--- a/src/Esfa.Vacancy.UnitTests/SearchApprenticeship/Api/Orchestrators/GivenASearchApprenticeshipVacanciesOrchestrator.cs
+++ b/src/Esfa.Vacancy.UnitTests/SearchApprenticeship/Api/Orchestrators/GivenASearchApprenticeshipVacanciesOrchestrator.cs
@@ -7,6 +7,7 @@ using AutoMapper;
 using Esfa.Vacancy.Api.Core.Validation;
 using Esfa.Vacancy.Api.Types;
 using Esfa.Vacancy.Application.Queries.SearchApprenticeshipVacancies;
+using Esfa.Vacancy.Domain.Interfaces;
 using Esfa.Vacancy.Domain.Validation;
 using Esfa.Vacancy.Infrastructure.Settings;
 using Esfa.Vacancy.Register.Api.Orchestrators;

--- a/src/Esfa.Vacancy.UnitTests/SearchApprenticeship/Api/Orchestrators/GivenASearchApprenticeshipVacanciesOrchestrator.cs
+++ b/src/Esfa.Vacancy.UnitTests/SearchApprenticeship/Api/Orchestrators/GivenASearchApprenticeshipVacanciesOrchestrator.cs
@@ -7,9 +7,9 @@ using AutoMapper;
 using Esfa.Vacancy.Api.Core.Validation;
 using Esfa.Vacancy.Api.Types;
 using Esfa.Vacancy.Application.Queries.SearchApprenticeshipVacancies;
+using Esfa.Vacancy.Domain.Constants;
 using Esfa.Vacancy.Domain.Interfaces;
 using Esfa.Vacancy.Domain.Validation;
-using Esfa.Vacancy.Infrastructure.Settings;
 using Esfa.Vacancy.Register.Api.Orchestrators;
 using FluentAssertions;
 using FluentValidation;
@@ -59,7 +59,7 @@ namespace Esfa.Vacancy.UnitTests.SearchApprenticeship.Api.Orchestrators
 
             var mockSettings = new Mock<IProvideSettings>();
             mockSettings
-                .Setup(x => x.GetSetting(ApplicationSettingKeyConstants.LiveApprenticeshipVacancyBaseUrlKey))
+                .Setup(x => x.GetSetting(ApplicationSettingKeys.LiveApprenticeshipVacancyBaseUrlKey))
                 .Returns(FAABaseUrl);
 
             _mockValidationExceptionBuilder = _fixture.Freeze<Mock<IValidationExceptionBuilder>>(composer => composer.Do(mock => mock


### PR DESCRIPTION
I had to move the Settings interface and constants in the domain layer from infrastructure to allow access to the application layer. This is the pattern we are following anyway. A lot of files have changed due to this namespace change.  

I have added a new IsSandboxEnvironment setting to avoid calls to the services that persist data. Only the existence of the setting is enough, value is not important. So in production environment we have to not deploy the setting at all. 