### PR TITLE
RA-1476 Name field shouldn't allow number characters

### DIFF
--- a/src/Esfa.Vacancy.Application/Commands/CreateApprenticeship/Validators/ContactDetailsValidator.cs
+++ b/src/Esfa.Vacancy.Application/Commands/CreateApprenticeship/Validators/ContactDetailsValidator.cs
@@ -10,7 +10,7 @@ namespace Esfa.Vacancy.Application.Commands.CreateApprenticeship.Validators
             RuleFor(request => request.ContactName)
                 .MaximumLength(100)
                 .WithErrorCode(ErrorCodes.CreateApprenticeship.ContactName)
-                .MatchesAllowedFreeTextCharacters()
+                .MustBeAValidName()
                 .WithErrorCode(ErrorCodes.CreateApprenticeship.ContactName)
                 .When(request => string.IsNullOrWhiteSpace(request.ContactName) == false);
 

--- a/src/Esfa.Vacancy.Application/Commands/CreateApprenticeship/Validators/Extensions.cs
+++ b/src/Esfa.Vacancy.Application/Commands/CreateApprenticeship/Validators/Extensions.cs
@@ -15,6 +15,14 @@ namespace Esfa.Vacancy.Application.Commands.CreateApprenticeship.Validators
         private const string RegexPostcode = @"^(([gG][iI][rR] {0,}0[aA]{2})|((([a-pr-uwyzA-PR-UWYZ][a-hk-yA-HK-Y]?[0-9][0-9]?)|(([a-pr-uwyzA-PR-UWYZ][0-9][a-hjkstuwA-HJKSTUW])|([a-pr-uwyzA-PR-UWYZ][a-hk-yA-HK-Y][0-9][abehmnprv-yABEHMNPRV-Y]))) {0,}[0-9][abd-hjlnp-uw-zABD-HJLNP-UW-Z]{2}))$";
         private const string RegexEmailAddress = @"^[a-zA-Z0-9\u0080-\uFFA7?$#()""'!,+\-=_:;.&€£*%\s\/]+@[a-zA-Z0-9\u0080-\uFFA7?$#()""'!,+\-=_:;.&€£*%\s\/]+\.([a-zA-Z0-9\u0080-\uFFA7]{2,10})$";
         private const string RegexPhoneNumber = @"^[0-9+\s-()]{8,16}$";
+        private const string RegexNameWhiteList = @"^[a-zA-Z()',+\-\s]+$";
+
+        public static IRuleBuilderOptions<T, string> MustBeAValidName<T>(
+            this IRuleBuilder<T, string> rule)
+        {
+            return rule.Matches(RegexNameWhiteList)
+                .WithMessage(ErrorMessages.CreateApprenticeship.InvalidPropertyValue);
+        }
 
         public static IRuleBuilderOptions<T, string> MustBeAValidPhoneNumber<T>(
             this IRuleBuilder<T, string> rule)

--- a/src/Esfa.Vacancy.UnitTests/CreateApprenticeship/Application/GivenACreateApprenticeshipRequestValidator/WhenValidatingContactName.cs
+++ b/src/Esfa.Vacancy.UnitTests/CreateApprenticeship/Application/GivenACreateApprenticeshipRequestValidator/WhenValidatingContactName.cs
@@ -23,8 +23,10 @@ namespace Esfa.Vacancy.UnitTests.CreateApprenticeship.Application.GivenACreateAp
                         "'Contact Name' must be less than 101 characters. You entered 101 characters.",
                         true)
                     .SetName("And if length exceeds 100 then is invalid."),
-                new TestCaseData("<", "'Contact Name' can't contain invalid characters", true)
-                .SetName("And if contains special character then is invalid.")
+                new TestCaseData("{@<", "'Contact Name' is invalid.", true)
+                    .SetName("And if contains special character then is invalid."),
+                new TestCaseData("122134", "'Contact Name' is invalid.", true)
+                    .SetName("And if contains numbers then is invalid.")
             };
 
         [TestCaseSource(nameof(TestCases))]


### PR DESCRIPTION
I have added a regex found in the RAA for name field that allows alphas and few special characters only. 