### PR TITLE
RA-1584 Evaluate config setting for sandbox services

### DIFF
--- a/src/Esfa.Vacancy.Infrastructure/InfrastructureRegistry.cs
+++ b/src/Esfa.Vacancy.Infrastructure/InfrastructureRegistry.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.Diagnostics;
 using System.Reflection;
 using Esfa.Vacancy.Domain.Constants;
@@ -61,13 +62,13 @@ namespace Esfa.Vacancy.Infrastructure
             var isRunningUnderSandboxEnvironment =
                 _provideSettings.GetNullableSetting(ApplicationSettingKeys.UseSandboxServices);
 
-            if (string.IsNullOrWhiteSpace(isRunningUnderSandboxEnvironment))
+            if ("yes".Equals(isRunningUnderSandboxEnvironment, StringComparison.OrdinalIgnoreCase))
             {
-                For<ICreateApprenticeshipService>().Use<CreateApprenticeshipService>();
+                For<ICreateApprenticeshipService>().Use<CreateApprenticeshipSandboxService>();
             }
             else
             {
-                For<ICreateApprenticeshipService>().Use<CreateApprenticeshipSandboxService>();
+                For<ICreateApprenticeshipService>().Use<CreateApprenticeshipService>();
             }
         }
     }

--- a/src/Esfa.Vacancy.UnitTests/Shared/Infrastructure/GivenStructureMapRegistry.cs
+++ b/src/Esfa.Vacancy.UnitTests/Shared/Infrastructure/GivenStructureMapRegistry.cs
@@ -11,14 +11,18 @@ namespace Esfa.Vacancy.UnitTests.Shared.Infrastructure
 {
     public class GivenStructureMapRegistry
     {
-        [Test]
-        public void AndUseSandboxServiceIsEnabled()
+        [TestCase("yes", true, TestName = "And value is 'yes' in lowercase then use sandbox service.")]
+        [TestCase("YES", true, TestName = "And value is 'YES' in uppercase then use sandbox service.")]
+        [TestCase("Yes", true, TestName = "And value is 'Yes' in mixed-case then use sandbox service.")]
+        [TestCase("true", false, TestName = "And is any other value then use normal service.")]
+        [TestCase(null, false, TestName = "And is null then use normal service.")]
+        public void AndUseSandboxServiceIsEnabled(string value, bool useSandboxService)
         {
             var mockRequestContext = new Mock<IRequestContext>();
             var mockProvideSettings = new Mock<IProvideSettings>();
             mockProvideSettings
                 .Setup(ps => ps.GetNullableSetting(ApplicationSettingKeys.UseSandboxServices))
-                .Returns("something");
+                .Returns(value);
             var container = new Container(new InfrastructureRegistry(mockProvideSettings.Object));
 
             container.Configure(c =>
@@ -26,32 +30,10 @@ namespace Esfa.Vacancy.UnitTests.Shared.Infrastructure
                 c.For<IRequestContext>().Use(mockRequestContext.Object);
             });
 
-            Assert.That(container.GetInstance<IProvideSettings>(),
-                Is.SameAs(mockProvideSettings.Object));
-
             Assert.That(container.GetInstance<ICreateApprenticeshipService>(),
-                Is.InstanceOf<CreateApprenticeshipSandboxService>());
+                useSandboxService
+                    ? Is.InstanceOf<CreateApprenticeshipSandboxService>()
+                    : Is.InstanceOf<CreateApprenticeshipService>());
         }
-
-        [Test]
-        public void AndUseSandboxSeriveIsDisabled()
-        {
-            var mockRequestContext = new Mock<IRequestContext>();
-            var mockProvideSettings = new Mock<IProvideSettings>();
-            mockProvideSettings.Setup(ps => ps.GetNullableSetting(It.IsAny<string>())).Returns((string)null);
-            var container = new Container(new InfrastructureRegistry(mockProvideSettings.Object));
-
-            container.Configure(c =>
-            {
-                c.For<IRequestContext>().Use(mockRequestContext.Object);
-            });
-
-            Assert.That(container.GetInstance<IProvideSettings>(),
-                Is.SameAs(mockProvideSettings.Object));
-
-            Assert.That(container.GetInstance<ICreateApprenticeshipService>(),
-                Is.InstanceOf<CreateApprenticeshipService>());
-        }
-
     }
 }


### PR DESCRIPTION
The config setting was expected to be on certain environments only, hence a process of manually adding it where necessary was assumed. However, settings applied manually are discarded on deployment. To retain the settings they have to exist on the ARM parameters. 

Hence this change is now to always expect the setting with value as `yes` indicating use sandbox service. Any other value or non-existence will result in using persistent services. 