### PR TITLE
RA-1617 Fixed issue when using a monthly wage

### DIFF
--- a/src/Esfa.Vacancy.Application/Commands/CreateApprenticeship/HourlyWageCalculator.cs
+++ b/src/Esfa.Vacancy.Application/Commands/CreateApprenticeship/HourlyWageCalculator.cs
@@ -4,7 +4,7 @@ namespace Esfa.Vacancy.Application.Commands.CreateApprenticeship
 {
     public class HourlyWageCalculator : IHourlyWageCalculator
     {
-        private const decimal WeeksPerMonth = 4m;
+        private const decimal MonthsPerYear = 12m;
         private const decimal WeeksPerYear = 52m;
         private const string HoursPerWeekZeroErrorMessage = "HoursPerWeek must be greater than 0.";
         private const string IncorrectWageTypeErrorMessage = "WageUnit must be either 'Weekly', 'Monthly' or 'Annually'.";
@@ -22,10 +22,10 @@ namespace Esfa.Vacancy.Application.Commands.CreateApprenticeship
                     calculatedHourlyWage = decimal.Divide(wageValue, hoursPerWeek);
                     break;
                 case WageUnit.Monthly:
-                    calculatedHourlyWage = decimal.Divide(decimal.Divide(wageValue, WeeksPerMonth), hoursPerWeek);
+                    calculatedHourlyWage = decimal.Divide(decimal.Multiply(wageValue, MonthsPerYear), decimal.Multiply(WeeksPerYear, hoursPerWeek));
                     break;
                 case WageUnit.Annually:
-                    calculatedHourlyWage = decimal.Divide(decimal.Divide(wageValue, WeeksPerYear), hoursPerWeek);
+                    calculatedHourlyWage = decimal.Divide(wageValue, decimal.Multiply(WeeksPerYear, hoursPerWeek));
                     break;
                 default:
                     throw new ArgumentOutOfRangeException(nameof(wageUnit), wageUnit, IncorrectWageTypeErrorMessage);

--- a/src/Esfa.Vacancy.UnitTests/CreateApprenticeship/Application/GivenACreateApprenticeshipRequestValidator/AndWageTypeCustomWageFixed/WhenValidatingWageUnit.cs
+++ b/src/Esfa.Vacancy.UnitTests/CreateApprenticeship/Application/GivenACreateApprenticeshipRequestValidator/AndWageTypeCustomWageFixed/WhenValidatingWageUnit.cs
@@ -157,13 +157,13 @@ namespace Esfa.Vacancy.UnitTests.CreateApprenticeship.Application.GivenACreateAp
         };
 
         [TestCaseSource(nameof(TestCases))]
-        public async Task AndCheckingAllowedVersusAttemtpedWeeklyWage(WageUnit wageUnit, decimal allowedMinimumHourlyWage, decimal attemptedWeeklyWage, bool expectedIsValid)
+        public async Task AndCheckingAllowedVersusAttemtpedWeeklyWage(WageUnit wageUnit, decimal allowedMinimumHourlyWage, decimal attemptedFixedWage, bool expectedIsValid)
         {
             var request = new CreateApprenticeshipRequest
             {
                 WageType = WageType.CustomWageFixed,
                 WageUnit = wageUnit,
-                FixedWage = attemptedWeeklyWage,
+                FixedWage = attemptedFixedWage,
                 HoursPerWeek = 36,
                 ExpectedStartDate = _fixture.Create<DateTime>()
             };

--- a/src/Esfa.Vacancy.UnitTests/CreateApprenticeship/Application/GivenACreateApprenticeshipRequestValidator/AndWageTypeCustomWageFixed/WhenValidatingWageUnit.cs
+++ b/src/Esfa.Vacancy.UnitTests/CreateApprenticeship/Application/GivenACreateApprenticeshipRequestValidator/AndWageTypeCustomWageFixed/WhenValidatingWageUnit.cs
@@ -21,26 +21,26 @@ namespace Esfa.Vacancy.UnitTests.CreateApprenticeship.Application.GivenACreateAp
         private CreateApprenticeshipRequestValidator _validator;
         private Mock<IMinimumWageSelector> _mockSelector;
         private Mock<IHourlyWageCalculator> _mockCalculator;
-        private decimal _expectedAllowedWeeklyWage;
-        private decimal _expectedAttemptedWeeklyWage;
+        private decimal _expectedAllowedFixedWage;
+        private decimal _expectedAttemptedFixedWage;
 
         [SetUp]
         public void Setup()
         {
             _fixture = new Fixture().Customize(new AutoMoqCustomization());
 
-            _expectedAllowedWeeklyWage = _fixture.Create<decimal>();
-            _expectedAttemptedWeeklyWage = _fixture.Create<decimal>();
+            _expectedAllowedFixedWage = _fixture.Create<decimal>();
+            _expectedAttemptedFixedWage = _fixture.Create<decimal>();
 
             _mockSelector = _fixture.Freeze<Mock<IMinimumWageSelector>>();
             _mockSelector
                 .Setup(selector => selector.SelectHourlyRateAsync(It.IsAny<DateTime>()))
-                .ReturnsAsync(_expectedAllowedWeeklyWage);
+                .ReturnsAsync(_expectedAllowedFixedWage);
 
             _mockCalculator = _fixture.Freeze<Mock<IHourlyWageCalculator>>();
             _mockCalculator
                 .Setup(calculator => calculator.Calculate(It.IsAny<decimal>(), It.IsAny<WageUnit>(), It.IsAny<decimal>()))
-                .Returns(_expectedAttemptedWeeklyWage);
+                .Returns(_expectedAttemptedFixedWage);
 
             _validator = _fixture.Create<CreateApprenticeshipRequestValidator>();
         }
@@ -145,18 +145,24 @@ namespace Esfa.Vacancy.UnitTests.CreateApprenticeship.Application.GivenACreateAp
 
         private static List<TestCaseData> TestCases => new List<TestCaseData>
         {
-            new TestCaseData(3.5m, 125.99m, false).SetName("And attempted is less than allowed Then is invalid"),
-            new TestCaseData(3.5m, 126.00m, true).SetName("And attempted is same as allowed Then is valid"),
-            new TestCaseData(3.5m, 126.01m, true).SetName("And attempted is greater than allowed Then is valid")
+            new TestCaseData(WageUnit.Weekly, 3.5m, 125.99m, false).SetName("And attempted weekly is less than allowed Then is invalid"),
+            new TestCaseData(WageUnit.Weekly, 3.5m, 126.00m, true).SetName("And attempted weekly is same as allowed Then is valid"),
+            new TestCaseData(WageUnit.Weekly, 3.5m, 126.01m, true).SetName("And attempted weekly is greater than allowed Then is valid"),
+            new TestCaseData(WageUnit.Monthly, 3.5m, 545.99m, false).SetName("And attempted monthly is less than allowed Then is invalid"),
+            new TestCaseData(WageUnit.Monthly, 3.5m, 546.00m, true).SetName("And attempted monthly is same as allowed Then is valid"),
+            new TestCaseData(WageUnit.Monthly, 3.5m, 546.01m, true).SetName("And attempted monthly is greater than allowed Then is valid"),
+            new TestCaseData(WageUnit.Annually, 3.5m, 6551.99m, false).SetName("And attempted annually is less than allowed Then is invalid"),
+            new TestCaseData(WageUnit.Annually, 3.5m, 6552.00m, true).SetName("And attempted annually is same as allowed Then is valid"),
+            new TestCaseData(WageUnit.Annually, 3.5m, 6552.01m, true).SetName("And attempted annually is greater than allowed Then is valid")
         };
 
         [TestCaseSource(nameof(TestCases))]
-        public async Task AndCheckingAllowedVersusAttemtpedWeeklyWage(decimal allowedMinimumHourlyWage, decimal attemptedWeeklyWage, bool expectedIsValid)
+        public async Task AndCheckingAllowedVersusAttemtpedWeeklyWage(WageUnit wageUnit, decimal allowedMinimumHourlyWage, decimal attemptedWeeklyWage, bool expectedIsValid)
         {
             var request = new CreateApprenticeshipRequest
             {
                 WageType = WageType.CustomWageFixed,
-                WageUnit = WageUnit.Weekly,
+                WageUnit = wageUnit,
                 FixedWage = attemptedWeeklyWage,
                 HoursPerWeek = 36,
                 ExpectedStartDate = _fixture.Create<DateTime>()

--- a/src/Esfa.Vacancy.UnitTests/CreateApprenticeship/Application/GivenACreateApprenticeshipRequestValidator/AndWageTypeCustomWageRange/WhenValidatingWageUnit.cs
+++ b/src/Esfa.Vacancy.UnitTests/CreateApprenticeship/Application/GivenACreateApprenticeshipRequestValidator/AndWageTypeCustomWageRange/WhenValidatingWageUnit.cs
@@ -148,18 +148,24 @@ namespace Esfa.Vacancy.UnitTests.CreateApprenticeship.Application.GivenACreateAp
 
         private static List<TestCaseData> TestCases => new List<TestCaseData>
         {
-            new TestCaseData(3.5m, 125.99m, false).SetName("And attempted is less than allowed Then is invalid"),
-            new TestCaseData(3.5m, 126.0m, true).SetName("And attempted is same as allowed Then is valid"),
-            new TestCaseData(3.5m, 126.01m, true).SetName("And attempted is greater than allowed Then is valid")
+            new TestCaseData(WageUnit.Weekly, 3.5m, 125.99m, false).SetName("And attempted weekly is less than allowed Then is invalid"),
+            new TestCaseData(WageUnit.Weekly, 3.5m, 126.00m, true).SetName("And attempted weekly is same as allowed Then is valid"),
+            new TestCaseData(WageUnit.Weekly, 3.5m, 126.01m, true).SetName("And attempted weekly is greater than allowed Then is valid"),
+            new TestCaseData(WageUnit.Monthly, 3.5m, 545.99m, false).SetName("And attempted monthly is less than allowed Then is invalid"),
+            new TestCaseData(WageUnit.Monthly, 3.5m, 546.00m, true).SetName("And attempted monthly is same as allowed Then is valid"),
+            new TestCaseData(WageUnit.Monthly, 3.5m, 546.01m, true).SetName("And attempted monthly is greater than allowed Then is valid"),
+            new TestCaseData(WageUnit.Annually, 3.5m, 6551.99m, false).SetName("And attempted annually is less than allowed Then is invalid"),
+            new TestCaseData(WageUnit.Annually, 3.5m, 6552.00m, true).SetName("And attempted annually is same as allowed Then is valid"),
+            new TestCaseData(WageUnit.Annually, 3.5m, 6552.01m, true).SetName("And attempted annually is greater than allowed Then is valid")
         };
 
         [TestCaseSource(nameof(TestCases))]
-        public async Task AndCheckingAllowedVersusAttemtpedMinWage(decimal allowedMinimumHourlyWage, decimal attemptedMinWage, bool expectedIsValid)
+        public async Task AndCheckingAllowedVersusAttemtpedMinWage(WageUnit wageUnit, decimal allowedMinimumHourlyWage, decimal attemptedMinWage, bool expectedIsValid)
         {
             var request = new CreateApprenticeshipRequest
             {
                 WageType = WageType.CustomWageRange,
-                WageUnit = WageUnit.Weekly,
+                WageUnit = wageUnit,
                 HoursPerWeek = 36,
                 MinWage = attemptedMinWage,
                 ExpectedStartDate = _fixture.Create<DateTime>()
@@ -175,7 +181,7 @@ namespace Esfa.Vacancy.UnitTests.CreateApprenticeship.Application.GivenACreateAp
             _fixture.Inject<IHourlyWageCalculator>(new HourlyWageCalculator());
             _validator = _fixture.Create<CreateApprenticeshipRequestValidator>();
 
-            var result = await _validator.ValidateAsync(context);
+            var result = await _validator.ValidateAsync(context).ConfigureAwait(false);
 
             result.IsValid.Should().Be(expectedIsValid);
             if (!result.IsValid)

--- a/src/Esfa.Vacancy.UnitTests/CreateApprenticeship/Application/GivenAHourlyWageCalculator/WhenCallingCalculate.cs
+++ b/src/Esfa.Vacancy.UnitTests/CreateApprenticeship/Application/GivenAHourlyWageCalculator/WhenCallingCalculate.cs
@@ -4,22 +4,19 @@ using Esfa.Vacancy.Application.Commands.CreateApprenticeship;
 using FluentAssertions;
 using NUnit.Framework;
 
-namespace Esfa.Vacancy.UnitTests.CreateApprenticeship.Application.GivenAMinimumWageCalculator
+namespace Esfa.Vacancy.UnitTests.CreateApprenticeship.Application.GivenAHourlyWageCalculator
 {
     [TestFixture]
     public class WhenCallingCalculate
     {
         private static List<TestCaseData> TestCases => new List<TestCaseData>
         {
-            new TestCaseData(WageUnit.Weekly, 120m, 40, 3m).SetName("Then calculates correct value from weekly"),
-            new TestCaseData(WageUnit.Weekly, 130.0m, 36.0, 3.61m).SetName("Then calculates correct value from weekly"),
-            new TestCaseData(WageUnit.Weekly, 150m, 30, 5m).SetName("Then calculates correct value from weekly"),
-            new TestCaseData(WageUnit.Monthly, 480m, 40, 3m).SetName("Then calculates correct value from monthly"),
-            new TestCaseData(WageUnit.Monthly, 525m, 37.5, 3.5m).SetName("Then calculates correct value from monthly"),
-            new TestCaseData(WageUnit.Monthly, 600m, 30, 5m).SetName("Then calculates correct value from monthly"),
-            new TestCaseData(WageUnit.Annually, 6240m, 40, 3m).SetName("Then calculates correct value from annually"),
-            new TestCaseData(WageUnit.Annually, 6825m, 37.5, 3.5m).SetName("Then calculates correct value from annually"),
-            new TestCaseData(WageUnit.Annually, 7800m, 30, 5m).SetName("Then calculates correct value from annually")
+            new TestCaseData(WageUnit.Weekly, 120m, 40, 3m).SetName("Then calculates exact value from weekly"),
+            new TestCaseData(WageUnit.Weekly, 130.0m, 36.0, 3.61m).SetName("Then calculates approximate value from weekly"),
+            new TestCaseData(WageUnit.Monthly, 481m, 40, 2.77m).SetName("Then calculates approximate value from monthly"),
+            new TestCaseData(WageUnit.Monthly, 568.75m, 37.5, 3.5m).SetName("Then calculates exact value from monthly"),
+            new TestCaseData(WageUnit.Annually, 6825m, 37.5, 3.5m).SetName("Then calculates exact value from annually"),
+            new TestCaseData(WageUnit.Annually, 6826m, 37.5, 3.5m).SetName("Then calculates approximate value from annually")
         };
 
         [TestCaseSource(nameof(TestCases))]
@@ -29,7 +26,7 @@ namespace Esfa.Vacancy.UnitTests.CreateApprenticeship.Application.GivenAMinimumW
 
             var result = minimumWageCalculator.Calculate(minWage, wageUnit, (decimal)hoursPerWeek);
 
-            result.Should().BeApproximately(expectedResult, 2);
+            result.Should().BeApproximately(expectedResult, 0.005m);
         }
 
         [Test]

--- a/src/Esfa.Vacancy.UnitTests/Esfa.Vacancy.UnitTests.csproj
+++ b/src/Esfa.Vacancy.UnitTests/Esfa.Vacancy.UnitTests.csproj
@@ -192,7 +192,7 @@
     <Compile Include="CreateApprenticeship\Application\GivenACreateApprenticeshipRequestValidator\WhenValidatingTitle.cs" />
     <Compile Include="CreateApprenticeship\Application\GivenACreateApprenticeshipRequestValidator\WhenValidatingWithMatchesAllowedHtmlFreeTextCharacters.cs" />
     <Compile Include="CreateApprenticeship\Application\GivenACreateApprenticeshipRequestValidator\WhenValidatingWithMatchesAllowedFreeTextCharacters.cs" />
-    <Compile Include="CreateApprenticeship\Application\GivenAMinimumWageCalculator\WhenCallingCalculate.cs" />
+    <Compile Include="CreateApprenticeship\Application\GivenAHourlyWageCalculator\WhenCallingCalculate.cs" />
     <Compile Include="CreateApprenticeship\Application\GivenAMinimumWageSelector\WhenSelectingHourlyRate.cs" />
     <Compile Include="CreateApprenticeship\Application\GivenAWageTypeMapper\WhenMappingWageType.cs" />
     <Compile Include="GetApprenticeshipVacancy\Api\Mappings\GivenAnApprenticeshipMapper\WhenMappingIsNationwide.cs" />


### PR DESCRIPTION
Using 4 weeks for a month gives an incorrect result - would require 13 months to be equal to an annual amount.  Changed to ensure a month is equivalent to 52 weeks per year / 12 months per year.