### PR TITLE
RA-1705 NCS internal server error

### DIFF
--- a/src/Esfa.Vacancy.Infrastructure/Services/GetApprenticeshipService.cs
+++ b/src/Esfa.Vacancy.Infrastructure/Services/GetApprenticeshipService.cs
@@ -41,7 +41,7 @@ namespace Esfa.Vacancy.Infrastructure.Services
                                 v.Location = a;
                                 return v;
                             },
-                            splitOn: "AddressLine1",
+                            splitOn: "PostCode",
                             commandType: CommandType.StoredProcedure).ConfigureAwait(false);
 
                     var apprenticeshipVacancy = results.FirstOrDefault();

--- a/src/Esfa.Vacancy.Infrastructure/Services/GetTraineeshipService.cs
+++ b/src/Esfa.Vacancy.Infrastructure/Services/GetTraineeshipService.cs
@@ -40,7 +40,7 @@ namespace Esfa.Vacancy.Infrastructure.Services
                                 v.Location = a;
                                 return v;
                             },
-                            splitOn: "AddressLine1",
+                            splitOn: "PostCode",
                             commandType: CommandType.StoredProcedure);
 
                     var traineeshipVacancy = results.FirstOrDefault();


### PR DESCRIPTION
When AddressLine1 is null, an Address object wasn't being created.  Storedproc amended to have PostCode before AddressLine1 and Dapper to split on PostCode