### PR TITLE
ER-432 Retrieve Recruit Apprenticeship 

### DIFF
--- a/src/Esfa.Vacancy.Api.Types/ApprenticeshipVacancy.cs
+++ b/src/Esfa.Vacancy.Api.Types/ApprenticeshipVacancy.cs
@@ -43,6 +43,11 @@ namespace Esfa.Vacancy.Api.Types
         public string WageText { get; set; }
 
         /// <summary>
+        /// Additional information with regards to wages
+        /// </summary>
+        public string WageAdditionalInformation { get; set; }
+
+        /// <summary>
         /// Hours per week.
         /// </summary>
         public decimal? HoursPerWeek { get; set; }
@@ -206,11 +211,6 @@ namespace Esfa.Vacancy.Api.Types
         /// Vacancy apprenticeship level.
         /// </summary>
         public string ApprenticeshipLevel { get; set; }
-
-        /// <summary>
-        /// Additional information with regards to wages
-        /// </summary>
-        public string WageAdditionalInformation { get; set; }
 
         /// <summary>
         /// Instructions on how to apply for the vacancy

--- a/src/Esfa.Vacancy.Api.Types/ApprenticeshipVacancy.cs
+++ b/src/Esfa.Vacancy.Api.Types/ApprenticeshipVacancy.cs
@@ -10,7 +10,7 @@ namespace Esfa.Vacancy.Api.Types
         /// <summary>
         /// Reference number.
         /// </summary>
-        public int VacancyReference { get; set; }
+        public long VacancyReference { get; set; }
 
         /// <summary>
         /// Vacancy Title.
@@ -206,5 +206,20 @@ namespace Esfa.Vacancy.Api.Types
         /// Vacancy apprenticeship level.
         /// </summary>
         public string ApprenticeshipLevel { get; set; }
+
+        /// <summary>
+        /// Additional information with regards to wages
+        /// </summary>
+        public string WageAdditionalInformation { get; set; }
+
+        /// <summary>
+        /// Instructions on how to apply for the vacancy
+        /// </summary>
+        public string ApplicationInstructions { get; set; }
+
+        /// <summary>
+        /// The web URL for applying for the vacancy
+        /// </summary>
+        public string ApplicationUrl { get; set; }
     }
 }

--- a/src/Esfa.Vacancy.Api.Types/GeoCodedAddress.cs
+++ b/src/Esfa.Vacancy.Api.Types/GeoCodedAddress.cs
@@ -1,6 +1,6 @@
 ﻿namespace Esfa.Vacancy.Api.Types
 {
-    public class GeoCodedAddress
+    public struct GeoCodedAddress
     {
         /// <summary>
         /// Address line1.

--- a/src/Esfa.Vacancy.Api.Types/GeoPoint.cs
+++ b/src/Esfa.Vacancy.Api.Types/GeoPoint.cs
@@ -1,7 +1,13 @@
 ﻿namespace Esfa.Vacancy.Api.Types
 {
-    public class GeoPoint
+    public struct GeoPoint
     {
+        public GeoPoint(double latitude, double longitude)
+        {
+            Longitude = (decimal)longitude;
+            Latitude = (decimal)latitude;
+        }
+
         /// <summary>
         /// The longitude.
         /// </summary>

--- a/src/Esfa.Vacancy.Application/Commands/CreateApprenticeship/MinimumWageSelector.cs
+++ b/src/Esfa.Vacancy.Application/Commands/CreateApprenticeship/MinimumWageSelector.cs
@@ -8,9 +8,9 @@ namespace Esfa.Vacancy.Application.Commands.CreateApprenticeship
     public class MinimumWageSelector : IMinimumWageSelector
     {
         private const string MissingWageRangeErrorMessage = "No WageRange found for date: [{0:yyyy-MM-dd}]";
-        private readonly IGetAllApprenticeMinimumWagesService _minimumWagesService;
+        private readonly IGetMinimumWagesService _minimumWagesService;
 
-        public MinimumWageSelector(IGetAllApprenticeMinimumWagesService minimumWagesService)
+        public MinimumWageSelector(IGetMinimumWagesService minimumWagesService)
         {
             _minimumWagesService = minimumWagesService;
         }

--- a/src/Esfa.Vacancy.Application/Esfa.Vacancy.Application.csproj
+++ b/src/Esfa.Vacancy.Application/Esfa.Vacancy.Application.csproj
@@ -102,7 +102,7 @@
     <Compile Include="Commands\CreateApprenticeship\WageUnit.cs" />
     <Compile Include="Exceptions\UnauthorisedException.cs" />
     <Compile Include="Exceptions\ResourceNotFoundException.cs" />
-    <Compile Include="Interfaces\IGetAllApprenticeMinimumWagesService.cs" />
+    <Compile Include="Interfaces\IGetMinimumWagesService.cs" />
     <Compile Include="Interfaces\ITrainingDetailService.cs" />
     <Compile Include="Interfaces\IApprenticeshipSearchService.cs" />
     <Compile Include="Queries\GetTraineeshipVacancy\GetTraineeshipVacancyQueryHandler.cs" />

--- a/src/Esfa.Vacancy.Application/Interfaces/IGetMinimumWagesService.cs
+++ b/src/Esfa.Vacancy.Application/Interfaces/IGetMinimumWagesService.cs
@@ -4,7 +4,7 @@ using Esfa.Vacancy.Domain.Entities;
 
 namespace Esfa.Vacancy.Application.Interfaces
 {
-    public interface IGetAllApprenticeMinimumWagesService
+    public interface IGetMinimumWagesService
     {
         Task<IEnumerable<WageRange>> GetAllWagesAsync();
     }

--- a/src/Esfa.Vacancy.Application/Interfaces/IGetMinimumWagesService.cs
+++ b/src/Esfa.Vacancy.Application/Interfaces/IGetMinimumWagesService.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.Threading.Tasks;
 using Esfa.Vacancy.Domain.Entities;
 
@@ -7,5 +8,7 @@ namespace Esfa.Vacancy.Application.Interfaces
     public interface IGetMinimumWagesService
     {
         Task<IEnumerable<WageRange>> GetAllWagesAsync();
+
+        Task<WageRange> GetWageRange(DateTime expectedStartDate);
     }
 }

--- a/src/Esfa.Vacancy.Application/Interfaces/IGetMinimumWagesService.cs
+++ b/src/Esfa.Vacancy.Application/Interfaces/IGetMinimumWagesService.cs
@@ -9,6 +9,6 @@ namespace Esfa.Vacancy.Application.Interfaces
     {
         Task<IEnumerable<WageRange>> GetAllWagesAsync();
 
-        Task<WageRange> GetWageRange(DateTime expectedStartDate);
+        Task<WageRange> GetWageRangeAsync(DateTime expectedStartDate);
     }
 }

--- a/src/Esfa.Vacancy.Application/Interfaces/ITrainingDetailService.cs
+++ b/src/Esfa.Vacancy.Application/Interfaces/ITrainingDetailService.cs
@@ -9,5 +9,7 @@ namespace Esfa.Vacancy.Application.Interfaces
         Task<Framework> GetFrameworkDetailsAsync(int code);
         Task<IEnumerable<TrainingDetail>> GetAllFrameworkDetailsAsync();
         Task<IEnumerable<TrainingDetail>> GetAllStandardDetailsAsync();
+
+        Task<Standard> GetStandardDetailsAsync(int code);
     }
 }

--- a/src/Esfa.Vacancy.Application/Queries/GetApprenticeshipVacancy/GetApprenticeshipVacancyQueryHandler.cs
+++ b/src/Esfa.Vacancy.Application/Queries/GetApprenticeshipVacancy/GetApprenticeshipVacancyQueryHandler.cs
@@ -1,10 +1,6 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Threading.Tasks;
+﻿using System.Threading.Tasks;
 using Esfa.Vacancy.Application.Exceptions;
 using Esfa.Vacancy.Application.Interfaces;
-using Esfa.Vacancy.Domain.Entities;
 using Esfa.Vacancy.Domain.Interfaces;
 using FluentValidation;
 using MediatR;
@@ -54,7 +50,7 @@ namespace Esfa.Vacancy.Application.Queries.GetApprenticeshipVacancy
             }
             else if (vacancy.StandardCode.HasValue)
             {
-                var standard = await GetStandardDetailsAsync(vacancy.StandardCode.Value)
+                var standard = await _trainingDetailService.GetStandardDetailsAsync(vacancy.StandardCode.Value)
                                                            .ConfigureAwait(false);
                 vacancy.Standard = standard;
             }
@@ -62,20 +58,6 @@ namespace Esfa.Vacancy.Application.Queries.GetApprenticeshipVacancy
             return new GetApprenticeshipVacancyResponse { ApprenticeshipVacancy = vacancy };
         }
 
-        private async Task<Standard> GetStandardDetailsAsync(int code)
-        {
-            IEnumerable<TrainingDetail> standards = await _trainingDetailService.GetAllStandardDetailsAsync().ConfigureAwait(false);
-            try
-            {
-                TrainingDetail standard = standards.Single(td => td.TrainingCode.Equals(code.ToString()));
-                _logger.Info($"Training API returned Standard details for code {code}");
-                return new Standard { Code = code, Title = standard.Title, Uri = standard.Uri };
-            }
-            catch (InvalidOperationException ex)
-            {
-                _logger.Warn(ex, $"Standard details not found for {code}");
-                return null;
-            }
-        }
+
     }
 }

--- a/src/Esfa.Vacancy.Domain/Constants/ApplicationSettingKeys.cs
+++ b/src/Esfa.Vacancy.Domain/Constants/ApplicationSettingKeys.cs
@@ -11,5 +11,8 @@
         public const string CacheConnectionString = "CacheConnectionString";
         public const string UseSandboxServices = "UseSandboxServices";
         public const string CacheReferenceDataDuration = "CacheReferenceDataDuration";
+        public const string ErMongoConnectionString = "ErMongoConnectionString";
+        public const string ErMongoDatabaseName = "ErMongoDatabaseName";
+        public const string ErMongoCollectionName = "ErMongoCollectionName";
     }
 }

--- a/src/Esfa.Vacancy.Domain/Constants/ApplicationSettingKeys.cs
+++ b/src/Esfa.Vacancy.Domain/Constants/ApplicationSettingKeys.cs
@@ -11,8 +11,8 @@
         public const string CacheConnectionString = "CacheConnectionString";
         public const string UseSandboxServices = "UseSandboxServices";
         public const string CacheReferenceDataDuration = "CacheReferenceDataDuration";
-        public const string ErMongoConnectionString = "ErMongoConnectionString";
-        public const string ErMongoDatabaseName = "ErMongoDatabaseName";
-        public const string ErMongoCollectionName = "ErMongoCollectionName";
+        public const string RecruitMongoConnectionString = "RecruitMongoConnectionString";
+        public const string RecruitMongoDatabaseName = "RecruitMongoDatabaseName";
+        public const string RecruitMongoCollectionName = "RecruitMongoCollectionName";
     }
 }

--- a/src/Esfa.Vacancy.Domain/Entities/WageRange.cs
+++ b/src/Esfa.Vacancy.Domain/Entities/WageRange.cs
@@ -7,5 +7,7 @@ namespace Esfa.Vacancy.Domain.Entities
         public DateTime ValidFrom { get; set; }
         public DateTime ValidTo { get; set; }
         public decimal ApprenticeMinimumWage { get; set; }
+        public decimal NationalMinimumWage { get; set; }
+        public decimal NationalMaximumWage { get; set; }
     }
 }

--- a/src/Esfa.Vacancy.Infrastructure/Esfa.Vacancy.Infrastructure.csproj
+++ b/src/Esfa.Vacancy.Infrastructure/Esfa.Vacancy.Infrastructure.csproj
@@ -106,13 +106,13 @@
     <Compile Include="Factories\SqlDatabaseService.cs" />
     <Compile Include="InfrastructureRegistry.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
-    <Compile Include="Services\CachedGetAllApprenticeMinimumWagesService.cs" />
+    <Compile Include="Services\CachedGetMinimumWagesService.cs" />
     <Compile Include="Services\CachedTrainingDetailService.cs" />
     <Compile Include="Services\CreateApprenticeshipService.cs" />
     <Compile Include="Services\ApprenticeshipSearchService.cs" />
     <Compile Include="Services\CreateApprenticeshipSandboxService.cs" />
     <Compile Include="Services\GeoSearchResultDistanceSetter.cs" />
-    <Compile Include="Services\GetAllApprenticeMinimumWagesService.cs" />
+    <Compile Include="Services\GetMinimumWagesService.cs" />
     <Compile Include="Services\GetApprenticeshipService.cs" />
     <Compile Include="Services\GetTraineeshipService.cs" />
     <Compile Include="Services\IGeoSearchResultDistanceSetter.cs" />

--- a/src/Esfa.Vacancy.Infrastructure/InfrastructureRegistry.cs
+++ b/src/Esfa.Vacancy.Infrastructure/InfrastructureRegistry.cs
@@ -34,8 +34,8 @@ namespace Esfa.Vacancy.Infrastructure
             For<IElasticClient>().Use(context => context.GetInstance<ElasticClientFactory>().GetClient());
             For<ICacheService>().Singleton().Use<AzureRedisCacheService>();
 
-            For<IGetAllApprenticeMinimumWagesService>().Use<CachedGetAllApprenticeMinimumWagesService>()
-                .Ctor<IGetAllApprenticeMinimumWagesService>().Is<GetAllApprenticeMinimumWagesService>();
+            For<IGetMinimumWagesService>().Use<CachedGetMinimumWagesService>()
+                .Ctor<IGetMinimumWagesService>().Is<GetMinimumWagesService>();
 
             For<ITrainingDetailService>().Use<CachedTrainingDetailService>()
                 .Ctor<ITrainingDetailService>().Is<TrainingDetailService>();

--- a/src/Esfa.Vacancy.Infrastructure/Services/CachedGetMinimumWagesService.cs
+++ b/src/Esfa.Vacancy.Infrastructure/Services/CachedGetMinimumWagesService.cs
@@ -1,4 +1,6 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
 using System.Threading.Tasks;
 using Esfa.Vacancy.Application.Interfaces;
 using Esfa.Vacancy.Domain.Entities;
@@ -27,6 +29,15 @@ namespace Esfa.Vacancy.Infrastructure.Services
             _logger.Debug("Cache hit for GetMinimumWagesService");
 
             return await _cacheService.CacheAsideAsync(CacheKey, _minimumWagesService.GetAllWagesAsync);
+        }
+
+        public async Task<WageRange> GetWageRange(DateTime expectedStartDate)
+        {
+            var ranges = await GetAllWagesAsync();
+
+            return ranges?.FirstOrDefault(range =>
+                range.ValidFrom.Date <= expectedStartDate.Date &&
+                range.ValidTo.Date >= expectedStartDate.Date);
         }
     }
 }

--- a/src/Esfa.Vacancy.Infrastructure/Services/CachedGetMinimumWagesService.cs
+++ b/src/Esfa.Vacancy.Infrastructure/Services/CachedGetMinimumWagesService.cs
@@ -15,7 +15,7 @@ namespace Esfa.Vacancy.Infrastructure.Services
         private readonly ILog _logger;
         private readonly ICacheService _cacheService;
 
-        private const string CacheKey = "VacancyApi.GetAllApprenticeMinimumWages";
+        private const string CacheKey = "VacancyApi.WageRanges";
 
         public CachedGetMinimumWagesService(IGetMinimumWagesService minimumWagesService, ILog logger, ICacheService cacheService)
         {

--- a/src/Esfa.Vacancy.Infrastructure/Services/CachedGetMinimumWagesService.cs
+++ b/src/Esfa.Vacancy.Infrastructure/Services/CachedGetMinimumWagesService.cs
@@ -35,7 +35,7 @@ namespace Esfa.Vacancy.Infrastructure.Services
         {
             var ranges = await GetAllWagesAsync();
 
-            return ranges?.FirstOrDefault(range =>
+            return ranges?.Single(range =>
                 range.ValidFrom.Date <= expectedStartDate.Date &&
                 range.ValidTo.Date >= expectedStartDate.Date);
         }

--- a/src/Esfa.Vacancy.Infrastructure/Services/CachedGetMinimumWagesService.cs
+++ b/src/Esfa.Vacancy.Infrastructure/Services/CachedGetMinimumWagesService.cs
@@ -31,7 +31,7 @@ namespace Esfa.Vacancy.Infrastructure.Services
             return await _cacheService.CacheAsideAsync(CacheKey, _minimumWagesService.GetAllWagesAsync);
         }
 
-        public async Task<WageRange> GetWageRange(DateTime expectedStartDate)
+        public async Task<WageRange> GetWageRangeAsync(DateTime expectedStartDate)
         {
             var ranges = await GetAllWagesAsync();
 

--- a/src/Esfa.Vacancy.Infrastructure/Services/CachedGetMinimumWagesService.cs
+++ b/src/Esfa.Vacancy.Infrastructure/Services/CachedGetMinimumWagesService.cs
@@ -7,15 +7,15 @@ using SFA.DAS.NLog.Logger;
 
 namespace Esfa.Vacancy.Infrastructure.Services
 {
-    public class CachedGetAllApprenticeMinimumWagesService : IGetAllApprenticeMinimumWagesService
+    public class CachedGetMinimumWagesService : IGetMinimumWagesService
     {
-        private readonly IGetAllApprenticeMinimumWagesService _minimumWagesService;
+        private readonly IGetMinimumWagesService _minimumWagesService;
         private readonly ILog _logger;
         private readonly ICacheService _cacheService;
 
         private const string CacheKey = "VacancyApi.GetAllApprenticeMinimumWages";
 
-        public CachedGetAllApprenticeMinimumWagesService(IGetAllApprenticeMinimumWagesService minimumWagesService, ILog logger, ICacheService cacheService)
+        public CachedGetMinimumWagesService(IGetMinimumWagesService minimumWagesService, ILog logger, ICacheService cacheService)
         {
             _minimumWagesService = minimumWagesService;
             _logger = logger;
@@ -24,7 +24,7 @@ namespace Esfa.Vacancy.Infrastructure.Services
 
         public async Task<IEnumerable<WageRange>> GetAllWagesAsync()
         {
-            _logger.Debug("Cache hit for GetAllApprenticeMinimumWagesService");
+            _logger.Debug("Cache hit for GetMinimumWagesService");
 
             return await _cacheService.CacheAsideAsync(CacheKey, _minimumWagesService.GetAllWagesAsync);
         }

--- a/src/Esfa.Vacancy.Infrastructure/Services/CachedTrainingDetailService.cs
+++ b/src/Esfa.Vacancy.Infrastructure/Services/CachedTrainingDetailService.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections.Generic;
+using System.Linq;
 using System.Threading.Tasks;
 using Esfa.Vacancy.Application.Interfaces;
 using Esfa.Vacancy.Domain.Entities;
@@ -46,6 +47,14 @@ namespace Esfa.Vacancy.Infrastructure.Services
                                           async () => await _trainingDetailService.GetAllStandardDetailsAsync()
                                                                                   .ConfigureAwait(false))
                                       .ConfigureAwait(false);
+        }
+
+        public async Task<Standard> GetStandardDetailsAsync(int code)
+        {
+            //Since the whole list is cached, try to get it from the cache
+            var standards = await GetAllStandardDetailsAsync().ConfigureAwait(false);
+            var standard = standards.SingleOrDefault(td => td.TrainingCode.Equals(code.ToString()));
+            return standard == null ? null : new Standard { Code = code, Title = standard.Title, Uri = standard.Uri };
         }
     }
 }

--- a/src/Esfa.Vacancy.Infrastructure/Services/GetMinimumWagesService.cs
+++ b/src/Esfa.Vacancy.Infrastructure/Services/GetMinimumWagesService.cs
@@ -10,12 +10,12 @@ using Esfa.Vacancy.Infrastructure.Factories;
 
 namespace Esfa.Vacancy.Infrastructure.Services
 {
-    public class GetAllApprenticeMinimumWagesService : IGetAllApprenticeMinimumWagesService
+    public class GetMinimumWagesService : IGetMinimumWagesService
     {
         private readonly SqlDatabaseService _sqlDatabaseService;
-        private const string GetAllApprenticeMinimumWagesStoredProc = "[VACANCY_API].[GetAllApprenticeMinimumWages]";
+        private const string GetAllApprenticeMinimumWagesStoredProc = "[VACANCY_API].[GetWageRanges]";
 
-        public GetAllApprenticeMinimumWagesService(SqlDatabaseService sqlDatabaseService)
+        public GetMinimumWagesService(SqlDatabaseService sqlDatabaseService)
         {
             _sqlDatabaseService = sqlDatabaseService;
         }

--- a/src/Esfa.Vacancy.Infrastructure/Services/GetMinimumWagesService.cs
+++ b/src/Esfa.Vacancy.Infrastructure/Services/GetMinimumWagesService.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Data;
+using System.Linq;
 using System.Threading.Tasks;
 using Dapper;
 using Esfa.Vacancy.Application.Interfaces;
@@ -40,6 +41,15 @@ namespace Esfa.Vacancy.Infrastructure.Services
             {
                 throw new InfrastructureException(e);
             }
+        }
+
+        public async Task<WageRange> GetWageRange(DateTime expectedStartDate)
+        {
+            var ranges = await GetAllWagesAsync();
+
+            return ranges?.FirstOrDefault(range =>
+                range.ValidFrom.Date <= expectedStartDate.Date &&
+                range.ValidTo.Date >= expectedStartDate.Date);
         }
     }
 }

--- a/src/Esfa.Vacancy.Infrastructure/Services/GetMinimumWagesService.cs
+++ b/src/Esfa.Vacancy.Infrastructure/Services/GetMinimumWagesService.cs
@@ -43,7 +43,7 @@ namespace Esfa.Vacancy.Infrastructure.Services
             }
         }
 
-        public async Task<WageRange> GetWageRange(DateTime expectedStartDate)
+        public async Task<WageRange> GetWageRangeAsync(DateTime expectedStartDate)
         {
             var ranges = await GetAllWagesAsync();
 

--- a/src/Esfa.Vacancy.Infrastructure/Services/GetMinimumWagesService.cs
+++ b/src/Esfa.Vacancy.Infrastructure/Services/GetMinimumWagesService.cs
@@ -47,7 +47,7 @@ namespace Esfa.Vacancy.Infrastructure.Services
         {
             var ranges = await GetAllWagesAsync();
 
-            return ranges?.FirstOrDefault(range =>
+            return ranges?.Single(range =>
                 range.ValidFrom.Date <= expectedStartDate.Date &&
                 range.ValidTo.Date >= expectedStartDate.Date);
         }

--- a/src/Esfa.Vacancy.Register.Api/DependencyResolution/DefaultRegistry.cs
+++ b/src/Esfa.Vacancy.Register.Api/DependencyResolution/DefaultRegistry.cs
@@ -16,9 +16,6 @@
 // --------------------------------------------------------------------------------------------------------------------
 
 using AutoMapper;
-using Esfa.Vacancy.Application.Queries.GetApprenticeshipVacancy;
-using Esfa.Vacancy.Application.Queries.GetTraineeshipVacancy;
-using Esfa.Vacancy.Application.Queries.SearchApprenticeshipVacancies;
 using FluentValidation;
 using MediatR;
 
@@ -44,9 +41,6 @@ namespace Esfa.Vacancy.Register.Api.DependencyResolution
 
             For<IConfigurationProvider>().Singleton().Use(AutoMapperConfig.Configure());
             For<IMapper>().Use(ctx => new Mapper(ctx.GetInstance<IConfigurationProvider>()));
-            For<IValidator<SearchApprenticeshipVacanciesRequest>>().Singleton().Use<SearchApprenticeshipVacanciesRequestValidator>();
-            For<IValidator<GetApprenticeshipVacancyRequest>>().Singleton().Use<GetApprenticeshipVacancyValidator>();
-            For<IValidator<GetTraineeshipVacancyRequest>>().Singleton().Use<GetTraineeshipVacancyValidator>();
         }
     }
 }

--- a/src/Esfa.Vacancy.Register.Api/DependencyResolution/IoC.cs
+++ b/src/Esfa.Vacancy.Register.Api/DependencyResolution/IoC.cs
@@ -28,8 +28,8 @@ namespace Esfa.Vacancy.Register.Api.DependencyResolution
             return new Container(c =>
             {
                 c.AddRegistry<DefaultRegistry>();
-                c.AddRegistry<WebRegistry>();
                 c.AddRegistry<InfrastructureRegistry>();
+                c.AddRegistry<WebRegistry>();
             });
         }
     }

--- a/src/Esfa.Vacancy.Register.Api/DependencyResolution/WebRegistry.cs
+++ b/src/Esfa.Vacancy.Register.Api/DependencyResolution/WebRegistry.cs
@@ -28,9 +28,9 @@ namespace Esfa.Vacancy.Register.Api.DependencyResolution
             For<IValidator<GetTraineeshipVacancyRequest>>().Singleton().Use<GetTraineeshipVacancyValidator>();
 
             For<IClient>().Use<Client>()
-                .Ctor<string>("connectionString").Is(context => context.GetInstance<IProvideSettings>().GetSetting(ApplicationSettingKeys.ErMongoConnectionString))
-                .Ctor<string>("databaseName").Is(context => context.GetInstance<IProvideSettings>().GetSetting(ApplicationSettingKeys.ErMongoDatabaseName))
-                .Ctor<string>("collectionName").Is(context => context.GetInstance<IProvideSettings>().GetSetting(ApplicationSettingKeys.ErMongoCollectionName));
+                .Ctor<string>("connectionString").Is(context => context.GetInstance<IProvideSettings>().GetSetting(ApplicationSettingKeys.RecruitMongoConnectionString))
+                .Ctor<string>("databaseName").Is(context => context.GetInstance<IProvideSettings>().GetSetting(ApplicationSettingKeys.RecruitMongoDatabaseName))
+                .Ctor<string>("collectionName").Is(context => context.GetInstance<IProvideSettings>().GetSetting(ApplicationSettingKeys.RecruitMongoCollectionName));
         }
     }
 }

--- a/src/Esfa.Vacancy.Register.Api/DependencyResolution/WebRegistry.cs
+++ b/src/Esfa.Vacancy.Register.Api/DependencyResolution/WebRegistry.cs
@@ -1,7 +1,14 @@
 ﻿using System.Web;
 using Esfa.Vacancy.Api.Core;
+using Esfa.Vacancy.Application.Queries.GetApprenticeshipVacancy;
+using Esfa.Vacancy.Application.Queries.GetTraineeshipVacancy;
+using Esfa.Vacancy.Application.Queries.SearchApprenticeshipVacancies;
+using Esfa.Vacancy.Domain.Constants;
+using Esfa.Vacancy.Domain.Interfaces;
+using FluentValidation;
 using MediatR;
 using SFA.DAS.NLog.Logger;
+using SFA.DAS.Recruit.Vacancies.Client;
 
 namespace Esfa.Vacancy.Register.Api.DependencyResolution
 {
@@ -15,6 +22,15 @@ namespace Esfa.Vacancy.Register.Api.DependencyResolution
             For<SingleInstanceFactory>().Use<SingleInstanceFactory>(ctx => t => ctx.GetInstance(t));
             For<MultiInstanceFactory>().Use<MultiInstanceFactory>(ctx => t => ctx.GetAllInstances(t));
             For<IMediator>().Use<Mediator>();
+
+            For<IValidator<SearchApprenticeshipVacanciesRequest>>().Singleton().Use<SearchApprenticeshipVacanciesRequestValidator>();
+            For<IValidator<GetApprenticeshipVacancyRequest>>().Singleton().Use<GetApprenticeshipVacancyValidator>();
+            For<IValidator<GetTraineeshipVacancyRequest>>().Singleton().Use<GetTraineeshipVacancyValidator>();
+
+            For<IClient>().Use<Client>()
+                .Ctor<string>("connectionString").Is(context => context.GetInstance<IProvideSettings>().GetSetting(ApplicationSettingKeys.ErMongoConnectionString))
+                .Ctor<string>("databaseName").Is(context => context.GetInstance<IProvideSettings>().GetSetting(ApplicationSettingKeys.ErMongoDatabaseName))
+                .Ctor<string>("collectionName").Is(context => context.GetInstance<IProvideSettings>().GetSetting(ApplicationSettingKeys.ErMongoCollectionName));
         }
     }
 }

--- a/src/Esfa.Vacancy.Register.Api/Esfa.Vacancy.Register.Api.csproj
+++ b/src/Esfa.Vacancy.Register.Api/Esfa.Vacancy.Register.Api.csproj
@@ -103,6 +103,12 @@
     <Reference Include="Microsoft.WindowsAzure.ServiceRuntime, Version=2.7.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35">
       <Private>False</Private>
     </Reference>
+    <Reference Include="MongoDB.Bson, Version=1.10.0.62, Culture=neutral, PublicKeyToken=f686731cfb9cc103, processorArchitecture=MSIL">
+      <HintPath>..\packages\mongocsharpdriver.1.10.0\lib\net35\MongoDB.Bson.dll</HintPath>
+    </Reference>
+    <Reference Include="MongoDB.Driver, Version=1.10.0.62, Culture=neutral, PublicKeyToken=f686731cfb9cc103, processorArchitecture=MSIL">
+      <HintPath>..\packages\mongocsharpdriver.1.10.0\lib\net35\MongoDB.Driver.dll</HintPath>
+    </Reference>
     <Reference Include="Newtonsoft.Json, Version=9.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
       <HintPath>..\packages\Newtonsoft.Json.9.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
     </Reference>
@@ -114,6 +120,9 @@
     </Reference>
     <Reference Include="SFA.DAS.NLog.Targets.Redis, Version=1.0.0.39208, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\packages\SFA.DAS.NLog.Targets.Redis.1.0.0.39208\lib\net45\SFA.DAS.NLog.Targets.Redis.dll</HintPath>
+    </Reference>
+    <Reference Include="SFA.DAS.Recruit.Vacancies.Client, Version=1.0.2.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\SFA.DAS.Recruit.Vacancies.Client.1.0.2\lib\net45\SFA.DAS.Recruit.Vacancies.Client.dll</HintPath>
     </Reference>
     <Reference Include="StackExchange.Redis, Version=1.2.6.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\packages\StackExchange.Redis.1.2.6\lib\net45\StackExchange.Redis.dll</HintPath>
@@ -284,7 +293,9 @@
     <Compile Include="Mappings\ApprenticeshipMapper.cs" />
     <Compile Include="Mappings\IApprenticeshipMapper.cs" />
     <Compile Include="Mappings\IntToEnumConverter.cs" />
+    <Compile Include="Mappings\IRecruitVacancyMapper.cs" />
     <Compile Include="Mappings\ITraineeshipMapper.cs" />
+    <Compile Include="Mappings\RecruitVacancyMapper.cs" />
     <Compile Include="Mappings\TraineeshipMapper.cs" />
     <Compile Include="Mappings\ApprenticeshipSummaryMapper.cs" />
     <Compile Include="Models\VersionInformation.cs" />

--- a/src/Esfa.Vacancy.Register.Api/Esfa.Vacancy.Register.Api.csproj
+++ b/src/Esfa.Vacancy.Register.Api/Esfa.Vacancy.Register.Api.csproj
@@ -295,7 +295,7 @@
     <Compile Include="Mappings\IntToEnumConverter.cs" />
     <Compile Include="Mappings\IRecruitVacancyMapper.cs" />
     <Compile Include="Mappings\ITraineeshipMapper.cs" />
-    <Compile Include="Mappings\RecruitVacancyMapper.cs" />
+    <Compile Include="Mappings\RecruitApprenticeshipMapper.cs" />
     <Compile Include="Mappings\TraineeshipMapper.cs" />
     <Compile Include="Mappings\ApprenticeshipSummaryMapper.cs" />
     <Compile Include="Models\VersionInformation.cs" />

--- a/src/Esfa.Vacancy.Register.Api/Mappings/ApprenticeshipMapper.cs
+++ b/src/Esfa.Vacancy.Register.Api/Mappings/ApprenticeshipMapper.cs
@@ -38,7 +38,7 @@ namespace Esfa.Vacancy.Register.Api.Mappings
                 ExpectedStartDate = apprenticeshipVacancy.ExpectedStartDate,
                 PostedDate = apprenticeshipVacancy.PostedDate,
                 ApplicationClosingDate = apprenticeshipVacancy.ApplicationClosingDate,
-                InterviewFromDate = apprenticeshipVacancy.InterviewFromDate, //TODO remove
+                InterviewFromDate = apprenticeshipVacancy.InterviewFromDate,
                 NumberOfPositions = apprenticeshipVacancy.NumberOfPositions,
                 EmployerName = apprenticeshipVacancy.IsAnonymousEmployer ? apprenticeshipVacancy.AnonymousEmployerName : apprenticeshipVacancy.EmployerName,
                 EmployerDescription = apprenticeshipVacancy.IsAnonymousEmployer ? apprenticeshipVacancy.AnonymousEmployerDescription : apprenticeshipVacancy.EmployerDescription,
@@ -47,7 +47,7 @@ namespace Esfa.Vacancy.Register.Api.Mappings
                 QualificationsRequired = apprenticeshipVacancy.QualificationsRequired,
                 SkillsRequired = apprenticeshipVacancy.SkillsRequired,
                 PersonalQualities = apprenticeshipVacancy.PersonalQualities,
-                ImportantInformation = apprenticeshipVacancy.ImportantInformation, //TODO check if can be removed
+                ImportantInformation = apprenticeshipVacancy.ImportantInformation,
                 FutureProspects = apprenticeshipVacancy.FutureProspects,
                 ThingsToConsider = apprenticeshipVacancy.ThingsToConsider,
                 IsNationwide = apprenticeshipVacancy.VacancyLocationTypeId == Nationwide,

--- a/src/Esfa.Vacancy.Register.Api/Mappings/ApprenticeshipMapper.cs
+++ b/src/Esfa.Vacancy.Register.Api/Mappings/ApprenticeshipMapper.cs
@@ -32,12 +32,13 @@ namespace Esfa.Vacancy.Register.Api.Mappings
                 WageUnit = MapWageUnit(apprenticeshipVacancy.WageUnitId),
                 WorkingWeek = apprenticeshipVacancy.WorkingWeek,
                 WageText = MapWage(apprenticeshipVacancy),
+                WageAdditionalInformation = null,
                 HoursPerWeek = apprenticeshipVacancy.HoursPerWeek,
                 ExpectedDuration = apprenticeshipVacancy.ExpectedDuration,
                 ExpectedStartDate = apprenticeshipVacancy.ExpectedStartDate,
                 PostedDate = apprenticeshipVacancy.PostedDate,
                 ApplicationClosingDate = apprenticeshipVacancy.ApplicationClosingDate,
-                InterviewFromDate = apprenticeshipVacancy.InterviewFromDate,
+                InterviewFromDate = apprenticeshipVacancy.InterviewFromDate, //TODO remove
                 NumberOfPositions = apprenticeshipVacancy.NumberOfPositions,
                 EmployerName = apprenticeshipVacancy.IsAnonymousEmployer ? apprenticeshipVacancy.AnonymousEmployerName : apprenticeshipVacancy.EmployerName,
                 EmployerDescription = apprenticeshipVacancy.IsAnonymousEmployer ? apprenticeshipVacancy.AnonymousEmployerDescription : apprenticeshipVacancy.EmployerDescription,
@@ -46,7 +47,7 @@ namespace Esfa.Vacancy.Register.Api.Mappings
                 QualificationsRequired = apprenticeshipVacancy.QualificationsRequired,
                 SkillsRequired = apprenticeshipVacancy.SkillsRequired,
                 PersonalQualities = apprenticeshipVacancy.PersonalQualities,
-                ImportantInformation = apprenticeshipVacancy.ImportantInformation,
+                ImportantInformation = apprenticeshipVacancy.ImportantInformation, //TODO check if can be removed
                 FutureProspects = apprenticeshipVacancy.FutureProspects,
                 ThingsToConsider = apprenticeshipVacancy.ThingsToConsider,
                 IsNationwide = apprenticeshipVacancy.VacancyLocationTypeId == Nationwide,
@@ -59,7 +60,7 @@ namespace Esfa.Vacancy.Register.Api.Mappings
                 ContactNumber = apprenticeshipVacancy.ContactNumber,
                 TrainingProviderName = apprenticeshipVacancy.TrainingProvider,
                 TrainingProviderUkprn = apprenticeshipVacancy.TrainingProviderUkprn,
-                TrainingProviderSite = apprenticeshipVacancy.TrainingProviderSite,
+                TrainingProviderSite = apprenticeshipVacancy.TrainingProviderSite, //This is mapped to provider's trading name
                 IsEmployerDisabilityConfident = apprenticeshipVacancy.IsDisabilityConfident,
                 ApprenticeshipLevel = MapEducationLevel(apprenticeshipVacancy.ApprenticeshipTypeId)
             };

--- a/src/Esfa.Vacancy.Register.Api/Mappings/IRecruitVacancyMapper.cs
+++ b/src/Esfa.Vacancy.Register.Api/Mappings/IRecruitVacancyMapper.cs
@@ -1,10 +1,11 @@
-﻿using Esfa.Vacancy.Api.Types;
+﻿using System.Threading.Tasks;
+using Esfa.Vacancy.Api.Types;
 using SFA.DAS.Recruit.Vacancies.Client.Entities;
 
 namespace Esfa.Vacancy.Register.Api.Mappings
 {
     public interface IRecruitVacancyMapper
     {
-        ApprenticeshipVacancy MapFromRecruitVacancy(LiveVacancy liveVacancy);
+        Task<ApprenticeshipVacancy> MapFromRecruitVacancy(LiveVacancy liveVacancy);
     }
 }

--- a/src/Esfa.Vacancy.Register.Api/Mappings/IRecruitVacancyMapper.cs
+++ b/src/Esfa.Vacancy.Register.Api/Mappings/IRecruitVacancyMapper.cs
@@ -1,0 +1,10 @@
+﻿using Esfa.Vacancy.Api.Types;
+using SFA.DAS.Recruit.Vacancies.Client.Entities;
+
+namespace Esfa.Vacancy.Register.Api.Mappings
+{
+    public interface IRecruitVacancyMapper
+    {
+        ApprenticeshipVacancy MapFromRecruitVacancy(LiveVacancy liveVacancy);
+    }
+}

--- a/src/Esfa.Vacancy.Register.Api/Mappings/RecruitVacancyMapper.cs
+++ b/src/Esfa.Vacancy.Register.Api/Mappings/RecruitVacancyMapper.cs
@@ -1,0 +1,141 @@
+﻿using System;
+using System.Linq;
+using Esfa.Vacancy.Application.Interfaces;
+using Esfa.Vacancy.Domain.Constants;
+using Esfa.Vacancy.Domain.Interfaces;
+using ApiTypes = Esfa.Vacancy.Api.Types;
+using recruitEntities = SFA.DAS.Recruit.Vacancies.Client.Entities;
+
+namespace Esfa.Vacancy.Register.Api.Mappings
+{
+    public class RecruitVacancyMapper : IRecruitVacancyMapper
+    {
+        private readonly IProvideSettings _provideSettings;
+        private readonly ITrainingDetailService _trainingDetailService;
+
+        public RecruitVacancyMapper(IProvideSettings provideSettings, ITrainingDetailService trainingDetailService)
+        {
+            _provideSettings = provideSettings;
+            _trainingDetailService = trainingDetailService;
+        }
+
+        public ApiTypes.ApprenticeshipVacancy MapFromRecruitVacancy(recruitEntities.LiveVacancy liveVacancy)
+        {
+            var liveVacancyBaseUrl = _provideSettings.GetSetting(ApplicationSettingKeys.LiveApprenticeshipVacancyBaseUrlKey);
+
+            var description = GetVacancyDescription(liveVacancy);
+
+            var trainingType =
+                (ApiTypes.TrainingType)Enum.Parse(typeof(ApiTypes.TrainingType), liveVacancy.ProgrammeType);
+
+            var trainingCode = GetTrainingCode(trainingType, liveVacancy.ProgrammeId);
+
+            var trainingTitle = GetTrainingTitle(trainingType, trainingCode);
+
+            var qualifications = GetVacancyQualification(liveVacancy);
+
+            var skills = string.Join(",", liveVacancy.Skills);
+
+            var apprenticeship = new ApiTypes.ApprenticeshipVacancy
+            {
+                VacancyReference = liveVacancy.VacancyReference,
+                Title = liveVacancy.Title,
+                ShortDescription = liveVacancy.ShortDescription,
+                Description = description,
+                WageUnit = ApiTypes.WageUnit.Annually,
+                WorkingWeek = liveVacancy.Wage.WorkingWeekDescription,
+                //WageText = liveVacancy.Wage.FixedWageYearlyAmount, //TODO write function to work out wage text depending on wage type
+                WageAdditionalInformation = liveVacancy.Wage.WageAdditionalInformation,
+                HoursPerWeek = liveVacancy.Wage.WeeklyHours,
+                //ExpectedDuration = liveVacancy.Wage.Duration, //TODO use extension
+                ExpectedStartDate = liveVacancy.StartDate,
+                PostedDate = liveVacancy.LiveDate,
+                ApplicationClosingDate = liveVacancy.ClosingDate,
+                NumberOfPositions = liveVacancy.NumberOfPositions,
+                EmployerName = liveVacancy.EmployerContactName,
+                EmployerDescription = liveVacancy.EmployerDescription,
+                EmployerWebsite = liveVacancy.EmployerWebsiteUrl,
+                ContactName = liveVacancy.EmployerContactName,
+                ContactEmail = liveVacancy.EmployerContactEmail,
+                ContactNumber = liveVacancy.EmployerContactPhone,
+                TrainingToBeProvided = liveVacancy.TrainingDescription,
+                QualificationsRequired = qualifications,
+                SkillsRequired = skills,
+                PersonalQualities = null,
+                ImportantInformation = null,
+                ApplicationInstructions = liveVacancy.ApplicationInstructions,
+                ApplicationUrl = liveVacancy.ApplicationUrl,
+                FutureProspects = liveVacancy.OutcomeDescription,
+                ThingsToConsider = liveVacancy.ThingsToConsider,
+                IsNationwide = false,
+                SupplementaryQuestion1 = null,
+                SupplementaryQuestion2 = null,
+                VacancyUrl = $"{liveVacancyBaseUrl}/{liveVacancy.VacancyReference}",
+                Location = MapFromRecruitAddress(liveVacancy.EmployerLocation),
+                TrainingProviderName = liveVacancy.TrainingProvider.Name,
+                TrainingProviderUkprn = liveVacancy.TrainingProvider.Ukprn.ToString(),
+                TrainingProviderSite = null,
+                IsEmployerDisabilityConfident = false,
+                ApprenticeshipLevel = liveVacancy.ProgrammeLevel,
+                TrainingType = trainingType,
+                TrainingCode = trainingCode,
+                TrainingTitle = trainingTitle
+            };
+
+
+            return apprenticeship;
+        }
+
+        private string GetTrainingTitle(ApiTypes.TrainingType trainingType, string trainingCode)
+        {
+            var code = int.Parse(trainingCode);
+            if (trainingType == ApiTypes.TrainingType.Framework)
+            {
+
+                var framework = _trainingDetailService.GetFrameworkDetailsAsync(code).Result;
+                return framework.Title;
+            }
+            else
+            {
+                var standard = _trainingDetailService.GetStandardDetailsAsync(code).Result;
+                return standard.Title;
+            }
+        }
+
+        private string GetVacancyDescription(recruitEntities.LiveVacancy liveVacancy)
+        {
+            return string.Concat(liveVacancy.Description, Environment.NewLine, liveVacancy.TrainingDescription);
+        }
+
+        private string GetVacancyQualification(recruitEntities.LiveVacancy liveVacancy)
+        {
+            var formattedDescriptions = liveVacancy.Qualifications.Select(q => $"{q.QualificationType} {q.Subject} (Grade {q.Grade}) {q.Weighting}");
+            return string.Join(",", formattedDescriptions);
+        }
+
+        private string GetTrainingCode(ApiTypes.TrainingType trainingType, string code)
+        {
+            var result = code;
+            if (trainingType == ApiTypes.TrainingType.Framework)
+            {
+                result = code.Split('-')[0];
+            }
+            return result;
+        }
+
+        private ApiTypes.GeoCodedAddress MapFromRecruitAddress(recruitEntities.Address address)
+        {
+            return new ApiTypes.GeoCodedAddress()
+            {
+                AddressLine1 = address.AddressLine1,
+                AddressLine2 = address.AddressLine2,
+                AddressLine3 = address.AddressLine3,
+                AddressLine4 = address.AddressLine4,
+                PostCode = address.Postcode,
+                GeoPoint = new ApiTypes.GeoPoint(address.Latitude, address.Longitude)
+            };
+        }
+
+    }
+
+}

--- a/src/Esfa.Vacancy.Register.Api/Mappings/RecruitVacancyMapper.cs
+++ b/src/Esfa.Vacancy.Register.Api/Mappings/RecruitVacancyMapper.cs
@@ -36,6 +36,8 @@ namespace Esfa.Vacancy.Register.Api.Mappings
 
             var skills = string.Join(",", liveVacancy.Skills);
 
+            var duration = GetDurationAsText(liveVacancy.Wage);
+
             var apprenticeship = new ApiTypes.ApprenticeshipVacancy
             {
                 VacancyReference = liveVacancy.VacancyReference,
@@ -47,7 +49,7 @@ namespace Esfa.Vacancy.Register.Api.Mappings
                 //WageText = liveVacancy.Wage.FixedWageYearlyAmount, //TODO write function to work out wage text depending on wage type
                 WageAdditionalInformation = liveVacancy.Wage.WageAdditionalInformation,
                 HoursPerWeek = liveVacancy.Wage.WeeklyHours,
-                //ExpectedDuration = liveVacancy.Wage.Duration, //TODO use extension
+                ExpectedDuration = duration,
                 ExpectedStartDate = liveVacancy.StartDate,
                 PostedDate = liveVacancy.LiveDate,
                 ApplicationClosingDate = liveVacancy.ClosingDate,
@@ -84,6 +86,13 @@ namespace Esfa.Vacancy.Register.Api.Mappings
 
 
             return apprenticeship;
+        }
+
+        private string GetDurationAsText(recruitEntities.Wage wage)
+        {
+            var unit = wage.Duration == 1 ? wage.DurationUnit : $"{wage.DurationUnit}s";
+
+            return $"{wage.Duration} {unit}";
         }
 
         private string GetTrainingTitle(ApiTypes.TrainingType trainingType, string trainingCode)

--- a/src/Esfa.Vacancy.Register.Api/Orchestrators/GetApprenticeshipVacancyOrchestrator.cs
+++ b/src/Esfa.Vacancy.Register.Api/Orchestrators/GetApprenticeshipVacancyOrchestrator.cs
@@ -49,7 +49,7 @@ namespace Esfa.Vacancy.Register.Api.Orchestrators
             else
             {
                 var liveVacancy = _recruitClient.GetVacancy(parsedId);
-                vacancy = _recruitMapper.MapFromRecruitVacancy(liveVacancy);
+                vacancy = await _recruitMapper.MapFromRecruitVacancy(liveVacancy);
             }
 
             return vacancy;

--- a/src/Esfa.Vacancy.Register.Api/Web.config
+++ b/src/Esfa.Vacancy.Register.Api/Web.config
@@ -24,6 +24,9 @@
     <add key="VacancySearchUrl" value="" />
     <add key="ApprenticeshipIndexAlias" value="" />
     <add key="CacheConnectionString" value="" />
+    <add key="ERMongoConnectionString" value=""/>
+    <add key="ERMongoDatabaseName" value=""/>
+    <add key="ERMongoCollectionName" value=""/>
   </appSettings>
   <system.diagnostics>
     <trace>

--- a/src/Esfa.Vacancy.Register.Api/Web.config
+++ b/src/Esfa.Vacancy.Register.Api/Web.config
@@ -24,9 +24,9 @@
     <add key="VacancySearchUrl" value="" />
     <add key="ApprenticeshipIndexAlias" value="" />
     <add key="CacheConnectionString" value="" />
-    <add key="ERMongoConnectionString" value=""/>
-    <add key="ERMongoDatabaseName" value=""/>
-    <add key="ERMongoCollectionName" value=""/>
+    <add key="RecruitMongoConnectionString" value=""/>
+    <add key="RecruitMongoDatabaseName" value=""/>
+    <add key="RecruitMongoCollectionName" value=""/>
   </appSettings>
   <system.diagnostics>
     <trace>

--- a/src/Esfa.Vacancy.Register.Api/packages.config
+++ b/src/Esfa.Vacancy.Register.Api/packages.config
@@ -24,10 +24,12 @@
   <package id="Microsoft.Net.Compilers" version="2.2.0" targetFramework="net452" developmentDependency="true" />
   <package id="Microsoft.Web.Infrastructure" version="1.0.0.0" targetFramework="net452" />
   <package id="Microsoft.WindowsAzure.ConfigurationManager" version="3.2.3" targetFramework="net452" />
+  <package id="mongocsharpdriver" version="1.10.0" targetFramework="net452" />
   <package id="Newtonsoft.Json" version="9.0.1" targetFramework="net452" />
   <package id="NLog" version="4.4.11" targetFramework="net452" />
   <package id="SFA.DAS.NLog.Logger" version="1.0.0.39208" targetFramework="net452" />
   <package id="SFA.DAS.NLog.Targets.Redis" version="1.0.0.39208" targetFramework="net452" />
+  <package id="SFA.DAS.Recruit.Vacancies.Client" version="1.0.2" targetFramework="net452" />
   <package id="StackExchange.Redis" version="1.2.6" targetFramework="net452" />
   <package id="StructureMap" version="4.5.0" targetFramework="net452" />
   <package id="StructureMap.MVC5" version="3.1.1.134" targetFramework="net452" />

--- a/src/Esfa.Vacancy.UnitTests/CreateApprenticeship/Application/GivenAMinimumWageSelector/WhenSelectingHourlyRate.cs
+++ b/src/Esfa.Vacancy.UnitTests/CreateApprenticeship/Application/GivenAMinimumWageSelector/WhenSelectingHourlyRate.cs
@@ -36,7 +36,7 @@ namespace Esfa.Vacancy.UnitTests.CreateApprenticeship.Application.GivenAMinimumW
             ValidTo = DateTime.MaxValue
         };
 
-        private Mock<IGetAllApprenticeMinimumWagesService> _mockMinimumWageService;
+        private Mock<IGetMinimumWagesService> _mockMinimumWageService;
         private MinimumWageSelector _minimumWageSelector;
         private IFixture _fixture;
 
@@ -61,7 +61,7 @@ namespace Esfa.Vacancy.UnitTests.CreateApprenticeship.Application.GivenAMinimumW
         {
             _fixture = new Fixture().Customize(new AutoMoqCustomization());
 
-            _mockMinimumWageService = _fixture.Freeze<Mock<IGetAllApprenticeMinimumWagesService>>();
+            _mockMinimumWageService = _fixture.Freeze<Mock<IGetMinimumWagesService>>();
             _mockMinimumWageService
                 .Setup(service => service.GetAllWagesAsync())
                 .ReturnsAsync(new List<WageRange>

--- a/src/Esfa.Vacancy.UnitTests/Esfa.Vacancy.UnitTests.csproj
+++ b/src/Esfa.Vacancy.UnitTests/Esfa.Vacancy.UnitTests.csproj
@@ -217,6 +217,15 @@
     <Compile Include="GetApprenticeshipVacancy\Api\Mappings\GivenRaaApprenticeshipMapper\WhenMappingLiveApprenticeshipEducationLevel.cs" />
     <Compile Include="GetApprenticeshipVacancy\Api\Mappings\GivenRaaApprenticeshipMapper\WhenMappingIsNationwide.cs" />
     <Compile Include="GetApprenticeshipVacancy\Api\Mappings\GivenRaaApprenticeshipMapper\WhenMappingVacancyUrl.cs" />
+    <Compile Include="GetApprenticeshipVacancy\Api\Mappings\GivenRecruitApprenticeshipMapper\RecruitApprenticeshipMapperBase.cs" />
+    <Compile Include="GetApprenticeshipVacancy\Api\Mappings\GivenRecruitApprenticeshipMapper\WhenMappingDuration.cs" />
+    <Compile Include="GetApprenticeshipVacancy\Api\Mappings\GivenRecruitApprenticeshipMapper\WhenMappingFromLiveVacancy.cs" />
+    <Compile Include="GetApprenticeshipVacancy\Api\Mappings\GivenRecruitApprenticeshipMapper\WhenMappingTrainingCode.cs" />
+    <Compile Include="GetApprenticeshipVacancy\Api\Mappings\GivenRecruitApprenticeshipMapper\WhenMappingTrainingTitle.cs" />
+    <Compile Include="GetApprenticeshipVacancy\Api\Mappings\GivenRecruitApprenticeshipMapper\WhenMappingTrainingType.cs" />
+    <Compile Include="GetApprenticeshipVacancy\Api\Mappings\GivenRecruitApprenticeshipMapper\WhenMappingVacancyUrl.cs" />
+    <Compile Include="GetApprenticeshipVacancy\Api\Mappings\GivenRecruitApprenticeshipMapper\WhenMappingWageText.cs" />
+    <Compile Include="GetApprenticeshipVacancy\Api\Mappings\GivenRecruitApprenticeshipMapper\WhenMappingWageUnit.cs" />
     <Compile Include="GetApprenticeshipVacancy\Api\Orchestrators\GivenAGetApprenticeshipVacancyOrchestrator\WhenRecruitVacancyRequested.cs" />
     <Compile Include="SearchApprenticeship\Api\Mappings\GivenASearchApprenticeshipParametersMapper\WhenMappingDistanceInMiles.cs" />
     <Compile Include="SearchApprenticeship\Api\Mappings\GivenASearchApprenticeshipParametersMapper\WhenMappingLongitude.cs" />

--- a/src/Esfa.Vacancy.UnitTests/Esfa.Vacancy.UnitTests.csproj
+++ b/src/Esfa.Vacancy.UnitTests/Esfa.Vacancy.UnitTests.csproj
@@ -55,6 +55,12 @@
     <Reference Include="MediatR, Version=3.0.1.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\packages\MediatR.3.0.1\lib\net45\MediatR.dll</HintPath>
     </Reference>
+    <Reference Include="MongoDB.Bson, Version=1.10.0.62, Culture=neutral, PublicKeyToken=f686731cfb9cc103, processorArchitecture=MSIL">
+      <HintPath>..\packages\mongocsharpdriver.1.10.0\lib\net35\MongoDB.Bson.dll</HintPath>
+    </Reference>
+    <Reference Include="MongoDB.Driver, Version=1.10.0.62, Culture=neutral, PublicKeyToken=f686731cfb9cc103, processorArchitecture=MSIL">
+      <HintPath>..\packages\mongocsharpdriver.1.10.0\lib\net35\MongoDB.Driver.dll</HintPath>
+    </Reference>
     <Reference Include="Moq, Version=4.7.63.0, Culture=neutral, PublicKeyToken=69f491c39445e920, processorArchitecture=MSIL">
       <HintPath>..\packages\Moq.4.7.63\lib\net45\Moq.dll</HintPath>
     </Reference>
@@ -81,6 +87,9 @@
     </Reference>
     <Reference Include="SFA.DAS.NLog.Logger, Version=1.0.0.39208, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\packages\SFA.DAS.NLog.Logger.1.0.0.39208\lib\net45\SFA.DAS.NLog.Logger.dll</HintPath>
+    </Reference>
+    <Reference Include="SFA.DAS.Recruit.Vacancies.Client, Version=1.0.2.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\SFA.DAS.Recruit.Vacancies.Client.1.0.2\lib\net45\SFA.DAS.Recruit.Vacancies.Client.dll</HintPath>
     </Reference>
     <Reference Include="StructureMap, Version=4.5.0.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\packages\StructureMap.4.5.0\lib\net45\StructureMap.dll</HintPath>
@@ -204,8 +213,9 @@
     <Compile Include="CreateApprenticeship\Application\GivenAMinimumWageSelector\WhenSelectingHourlyRate.cs" />
     <Compile Include="CreateApprenticeship\Application\GivenAWageTypeMapper\WhenMappingWageType.cs" />
     <Compile Include="Extensions\FixtureExtensions.cs" />
-    <Compile Include="GetApprenticeshipVacancy\Api\Mappings\GivenAnApprenticeshipMapper\WhenMappingLiveApprenticeshipEducationLevel.cs" />
-    <Compile Include="GetApprenticeshipVacancy\Api\Mappings\GivenAnApprenticeshipMapper\WhenMappingIsNationwide.cs" />
+    <Compile Include="GetApprenticeshipVacancy\Api\Mappings\GivenRaaApprenticeshipMapper\WhenMappingLiveApprenticeshipEducationLevel.cs" />
+    <Compile Include="GetApprenticeshipVacancy\Api\Mappings\GivenRaaApprenticeshipMapper\WhenMappingIsNationwide.cs" />
+    <Compile Include="GetApprenticeshipVacancy\Api\Orchestrators\GivenAGetApprenticeshipVacancyOrchestrator\WhenRecruitVacancyRequested.cs" />
     <Compile Include="SearchApprenticeship\Api\Mappings\GivenASearchApprenticeshipParametersMapper\WhenMappingDistanceInMiles.cs" />
     <Compile Include="SearchApprenticeship\Api\Mappings\GivenASearchApprenticeshipParametersMapper\WhenMappingLongitude.cs" />
     <Compile Include="SearchApprenticeship\Api\Mappings\GivenASearchApprenticeshipParametersMapper\WhenMappingLatitude.cs" />
@@ -245,16 +255,16 @@
     <Compile Include="SearchApprenticeship\Api\Mappings\GivenASearchApprenticeshipParametersMapper\WhenMappingPageNumber.cs" />
     <Compile Include="SearchApprenticeship\Api\Mappings\GivenASearchApprenticeshipParametersMapper\WhenMappingPageSize.cs" />
     <Compile Include="SearchApprenticeship\Api\Mappings\GivenASearchApprenticeshipParametersMapper\WhenMappingStandardCodes.cs" />
-    <Compile Include="GetApprenticeshipVacancy\Api\Mappings\GivenAnApprenticeshipMapper\WhenMappingLiveApprenticeshipTrainingDetails.cs" />
+    <Compile Include="GetApprenticeshipVacancy\Api\Mappings\GivenRaaApprenticeshipMapper\WhenMappingLiveApprenticeshipTrainingDetails.cs" />
     <Compile Include="Shared\Api\AutoMapperConfigTest.cs" />
-    <Compile Include="GetApprenticeshipVacancy\Api\Mappings\GivenAnApprenticeshipMapper\WhenMappingLiveApprenticeshipWageUnit.cs" />
-    <Compile Include="GetApprenticeshipVacancy\Api\Mappings\GivenAnApprenticeshipMapper\WhenMappingLiveApprenticeshipWithAmbiguousWage.cs" />
-    <Compile Include="GetApprenticeshipVacancy\Api\Mappings\GivenAnApprenticeshipMapper\WhenMappingLiveApprenticeshipWithLegacyTextWageType.cs" />
-    <Compile Include="GetApprenticeshipVacancy\Api\Mappings\GivenAnApprenticeshipMapper\WhenMappingLiveApprenticeshipWithLegacyWeeklyWageType.cs" />
-    <Compile Include="GetApprenticeshipVacancy\Api\Mappings\GivenAnApprenticeshipMapper\WhenMappingLiveApprenticeshipWithCustomWageType.cs" />
-    <Compile Include="GetApprenticeshipVacancy\Api\Mappings\GivenAnApprenticeshipMapper\WhenMappingLiveApprenticeshipWithCustomRangeWageType.cs" />
-    <Compile Include="GetApprenticeshipVacancy\Api\Mappings\GivenAnApprenticeshipMapper\WhenMappingLiveApprenticeshipWithApprenticeshipMinimumWageType.cs" />
-    <Compile Include="GetApprenticeshipVacancy\Api\Mappings\GivenAnApprenticeshipMapper\WhenMappingLiveApprenticeshipWithNationalMinimumWageType.cs" />
+    <Compile Include="GetApprenticeshipVacancy\Api\Mappings\GivenRaaApprenticeshipMapper\WhenMappingLiveApprenticeshipWageUnit.cs" />
+    <Compile Include="GetApprenticeshipVacancy\Api\Mappings\GivenRaaApprenticeshipMapper\WhenMappingLiveApprenticeshipWithAmbiguousWage.cs" />
+    <Compile Include="GetApprenticeshipVacancy\Api\Mappings\GivenRaaApprenticeshipMapper\WhenMappingLiveApprenticeshipWithLegacyTextWageType.cs" />
+    <Compile Include="GetApprenticeshipVacancy\Api\Mappings\GivenRaaApprenticeshipMapper\WhenMappingLiveApprenticeshipWithLegacyWeeklyWageType.cs" />
+    <Compile Include="GetApprenticeshipVacancy\Api\Mappings\GivenRaaApprenticeshipMapper\WhenMappingLiveApprenticeshipWithCustomWageType.cs" />
+    <Compile Include="GetApprenticeshipVacancy\Api\Mappings\GivenRaaApprenticeshipMapper\WhenMappingLiveApprenticeshipWithCustomRangeWageType.cs" />
+    <Compile Include="GetApprenticeshipVacancy\Api\Mappings\GivenRaaApprenticeshipMapper\WhenMappingLiveApprenticeshipWithApprenticeshipMinimumWageType.cs" />
+    <Compile Include="GetApprenticeshipVacancy\Api\Mappings\GivenRaaApprenticeshipMapper\WhenMappingLiveApprenticeshipWithNationalMinimumWageType.cs" />
     <Compile Include="GetApprenticeshipVacancy\Application\Queries\GivenAGetApprenticeshipVacancyQueryHandler\WhenGettingApprenticeshipVacancy.cs" />
     <Compile Include="GetApprenticeshipVacancy\Application\Queries\GivenAGetApprenticeshipVacancyValidator\WhenValidatingRequest.cs" />
     <Compile Include="SearchApprenticeship\Api\Orchestrators\GivenASearchApprenticeshipVacanciesOrchestrator.cs" />

--- a/src/Esfa.Vacancy.UnitTests/Esfa.Vacancy.UnitTests.csproj
+++ b/src/Esfa.Vacancy.UnitTests/Esfa.Vacancy.UnitTests.csproj
@@ -213,8 +213,10 @@
     <Compile Include="CreateApprenticeship\Application\GivenAMinimumWageSelector\WhenSelectingHourlyRate.cs" />
     <Compile Include="CreateApprenticeship\Application\GivenAWageTypeMapper\WhenMappingWageType.cs" />
     <Compile Include="Extensions\FixtureExtensions.cs" />
+    <Compile Include="GetApprenticeshipVacancy\Api\Mappings\GivenRaaApprenticeshipMapper\WhenMappingEmployerInformation.cs" />
     <Compile Include="GetApprenticeshipVacancy\Api\Mappings\GivenRaaApprenticeshipMapper\WhenMappingLiveApprenticeshipEducationLevel.cs" />
     <Compile Include="GetApprenticeshipVacancy\Api\Mappings\GivenRaaApprenticeshipMapper\WhenMappingIsNationwide.cs" />
+    <Compile Include="GetApprenticeshipVacancy\Api\Mappings\GivenRaaApprenticeshipMapper\WhenMappingVacancyUrl.cs" />
     <Compile Include="GetApprenticeshipVacancy\Api\Orchestrators\GivenAGetApprenticeshipVacancyOrchestrator\WhenRecruitVacancyRequested.cs" />
     <Compile Include="SearchApprenticeship\Api\Mappings\GivenASearchApprenticeshipParametersMapper\WhenMappingDistanceInMiles.cs" />
     <Compile Include="SearchApprenticeship\Api\Mappings\GivenASearchApprenticeshipParametersMapper\WhenMappingLongitude.cs" />

--- a/src/Esfa.Vacancy.UnitTests/GetApprenticeshipVacancy/Api/Mappings/GivenRaaApprenticeshipMapper/WhenMappingEmployerInformation.cs
+++ b/src/Esfa.Vacancy.UnitTests/GetApprenticeshipVacancy/Api/Mappings/GivenRaaApprenticeshipMapper/WhenMappingEmployerInformation.cs
@@ -1,0 +1,89 @@
+﻿using Esfa.Vacancy.Domain.Interfaces;
+using Esfa.Vacancy.Register.Api.Mappings;
+using FluentAssertions;
+using Moq;
+using NUnit.Framework;
+using NUnit.Framework.Internal;
+using Ploeh.AutoFixture;
+
+namespace Esfa.Vacancy.UnitTests.GetApprenticeshipVacancy.Api.Mappings.GivenRaaApprenticeshipMapper
+{
+    [TestFixture]
+    public class WhenMappingEmployerInformation
+    {
+        private ApprenticeshipMapper _sut;
+
+        [OneTimeSetUp]
+        public void FixtureSetup()
+        {
+            var provideSettings = new Mock<IProvideSettings>();
+            _sut = new ApprenticeshipMapper(provideSettings.Object);
+        }
+
+        [Test]
+        public void AndEmployerIsNotAnonymous_ThenDoNotReplaceEmployerNameAndDescription()
+        {
+            var vacancy = new Fixture().Build<Domain.Entities.ApprenticeshipVacancy>()
+                .With(v => v.WageUnitId, null)
+                .With(v => v.VacancyReferenceNumber, 1234)
+                .With(v => v.VacancyStatusId, 2)
+                .With(v => v.EmployerName, "ABC Ltd")
+                .With(v => v.EmployerDescription, "A plain company")
+                .With(v => v.EmployerWebsite, "http://www.google.co.uk")
+                .Without(v => v.AnonymousEmployerName)
+                .Without(v => v.AnonymousEmployerDescription)
+                .Without(v => v.AnonymousEmployerReason)
+                .Create();
+
+            var result = _sut.MapToApprenticeshipVacancy(vacancy);
+
+            result.VacancyReference.Should().Be(vacancy.VacancyReferenceNumber);
+            result.EmployerName.Should().Be("ABC Ltd");
+            result.EmployerDescription.Should().Be("A plain company");
+            result.EmployerWebsite.Should().Be("http://www.google.co.uk");
+            result.Location.Should().NotBeNull();
+            result.Location.AddressLine1.Should().NotBeNull();
+            result.Location.AddressLine2.Should().NotBeNull();
+            result.Location.AddressLine3.Should().NotBeNull();
+            result.Location.AddressLine4.Should().NotBeNull();
+            result.Location.AddressLine5.Should().NotBeNull();
+            result.Location.Town.Should().NotBeNull();
+            result.Location.PostCode.Should().NotBeNull();
+            result.Location.GeoPoint.Should().NotBeNull();
+            result.Location.GeoPoint.Longitude.Should().NotBeNull();
+            result.Location.GeoPoint.Latitude.Should().NotBeNull();
+        }
+
+        [Test]
+        public void AndEmployerIsAnonymous_ThenReplaceEmployerNameAndDescription()
+        {
+            var vacancy = new Fixture().Build<Domain.Entities.ApprenticeshipVacancy>()
+                .With(v => v.WageUnitId, null)
+                .With(v => v.VacancyReferenceNumber, 1234)
+                .With(v => v.VacancyStatusId, 2)
+                .With(v => v.EmployerName, "Her Majesties Secret Service")
+                .With(v => v.EmployerDescription, "A private description")
+                .With(v => v.AnonymousEmployerName, "ABC Ltd")
+                .With(v => v.AnonymousEmployerDescription, "A plain company")
+                .With(v => v.AnonymousEmployerReason, "Because I want to test")
+                .Create();
+
+            var result = _sut.MapToApprenticeshipVacancy(vacancy);
+
+            result.VacancyReference.Should().Be(vacancy.VacancyReferenceNumber);
+            result.EmployerName.Should().Be("ABC Ltd");
+            result.EmployerDescription.Should().Be("A plain company");
+            result.EmployerWebsite.Should().BeNullOrEmpty();
+            result.Location.AddressLine1.Should().BeNull();
+            result.Location.AddressLine2.Should().BeNull();
+            result.Location.AddressLine3.Should().BeNull();
+            result.Location.AddressLine4.Should().BeNull();
+            result.Location.AddressLine5.Should().BeNull();
+            result.Location.PostCode.Should().BeNull();
+            result.Location.GeoPoint.Latitude.Should().BeNull();
+            result.Location.GeoPoint.Longitude.Should().BeNull();
+            result.Location.Town.Should().NotBeNullOrWhiteSpace();
+
+        }
+    }
+}

--- a/src/Esfa.Vacancy.UnitTests/GetApprenticeshipVacancy/Api/Mappings/GivenRaaApprenticeshipMapper/WhenMappingIsNationwide.cs
+++ b/src/Esfa.Vacancy.UnitTests/GetApprenticeshipVacancy/Api/Mappings/GivenRaaApprenticeshipMapper/WhenMappingIsNationwide.cs
@@ -1,12 +1,11 @@
 ﻿using Esfa.Vacancy.Domain.Entities;
 using Esfa.Vacancy.Domain.Interfaces;
-using Esfa.Vacancy.Infrastructure.Settings;
 using Esfa.Vacancy.Register.Api.Mappings;
 using FluentAssertions;
 using Moq;
 using NUnit.Framework;
 
-namespace Esfa.Vacancy.UnitTests.GetApprenticeshipVacancy.Api.Mappings.GivenAnApprenticeshipMapper
+namespace Esfa.Vacancy.UnitTests.GetApprenticeshipVacancy.Api.Mappings.GivenRaaApprenticeshipMapper
 {
     [TestFixture]
     public class WhenMappingIsNationwide

--- a/src/Esfa.Vacancy.UnitTests/GetApprenticeshipVacancy/Api/Mappings/GivenRaaApprenticeshipMapper/WhenMappingLiveApprenticeshipEducationLevel.cs
+++ b/src/Esfa.Vacancy.UnitTests/GetApprenticeshipVacancy/Api/Mappings/GivenRaaApprenticeshipMapper/WhenMappingLiveApprenticeshipEducationLevel.cs
@@ -5,7 +5,7 @@ using FluentAssertions;
 using Moq;
 using NUnit.Framework;
 
-namespace Esfa.Vacancy.UnitTests.GetApprenticeshipVacancy.Api.Mappings.GivenAnApprenticeshipMapper
+namespace Esfa.Vacancy.UnitTests.GetApprenticeshipVacancy.Api.Mappings.GivenRaaApprenticeshipMapper
 {
     [TestFixture]
     public class WhenMappingLiveApprenticeshipEducationLevel

--- a/src/Esfa.Vacancy.UnitTests/GetApprenticeshipVacancy/Api/Mappings/GivenRaaApprenticeshipMapper/WhenMappingLiveApprenticeshipTrainingDetails.cs
+++ b/src/Esfa.Vacancy.UnitTests/GetApprenticeshipVacancy/Api/Mappings/GivenRaaApprenticeshipMapper/WhenMappingLiveApprenticeshipTrainingDetails.cs
@@ -1,13 +1,13 @@
 ﻿using Esfa.Vacancy.Domain.Entities;
 using Esfa.Vacancy.Domain.Interfaces;
-using Esfa.Vacancy.Infrastructure.Settings;
 using Esfa.Vacancy.Register.Api.Mappings;
 using Moq;
 using NUnit.Framework;
 using Ploeh.AutoFixture;
 using ApiTypes = Esfa.Vacancy.Api.Types;
+using ApprenticeshipVacancy = Esfa.Vacancy.Domain.Entities.ApprenticeshipVacancy;
 
-namespace Esfa.Vacancy.UnitTests.GetApprenticeshipVacancy.Api.Mappings.GivenAnApprenticeshipMapper
+namespace Esfa.Vacancy.UnitTests.GetApprenticeshipVacancy.Api.Mappings.GivenRaaApprenticeshipMapper
 {
     [TestFixture]
     public class WhenMappingLiveApprenticeshipTrainingDetails

--- a/src/Esfa.Vacancy.UnitTests/GetApprenticeshipVacancy/Api/Mappings/GivenRaaApprenticeshipMapper/WhenMappingLiveApprenticeshipWageUnit.cs
+++ b/src/Esfa.Vacancy.UnitTests/GetApprenticeshipVacancy/Api/Mappings/GivenRaaApprenticeshipMapper/WhenMappingLiveApprenticeshipWageUnit.cs
@@ -1,15 +1,15 @@
 ﻿using System.ComponentModel;
-using ApiTypes = Esfa.Vacancy.Api.Types;
 using Esfa.Vacancy.Domain.Entities;
 using Esfa.Vacancy.Domain.Interfaces;
-using Esfa.Vacancy.Infrastructure.Settings;
 using Esfa.Vacancy.Register.Api.Mappings;
 using FluentAssertions;
 using Moq;
 using NUnit.Framework;
 using Ploeh.AutoFixture;
+using ApiTypes = Esfa.Vacancy.Api.Types;
+using ApprenticeshipVacancy = Esfa.Vacancy.Domain.Entities.ApprenticeshipVacancy;
 
-namespace Esfa.Vacancy.UnitTests.GetApprenticeshipVacancy.Api.Mappings.GivenAnApprenticeshipMapper
+namespace Esfa.Vacancy.UnitTests.GetApprenticeshipVacancy.Api.Mappings.GivenRaaApprenticeshipMapper
 {
     [TestFixture]
     [Parallelizable(ParallelScope.Fixtures)]
@@ -31,7 +31,7 @@ namespace Esfa.Vacancy.UnitTests.GetApprenticeshipVacancy.Api.Mappings.GivenAnAp
                 .With(v => v.WageType, (int)LegacyWageType.Custom)
                 .With(v => v.WageUnitId, 99)
                 .Create();
-            
+
             Assert.Throws<InvalidEnumArgumentException>(() => _sut.MapToApprenticeshipVacancy(apprenticeshipVacancy));
         }
 
@@ -46,7 +46,7 @@ namespace Esfa.Vacancy.UnitTests.GetApprenticeshipVacancy.Api.Mappings.GivenAnAp
                 .With(v => v.WageType, (int)LegacyWageType.Custom)
                 .With(v => v.WageUnitId, wageUnitId)
                 .Create();
-            
+
             //Act
             var vacancy = _sut.MapToApprenticeshipVacancy(apprenticeshipVacancy);
             //Assert

--- a/src/Esfa.Vacancy.UnitTests/GetApprenticeshipVacancy/Api/Mappings/GivenRaaApprenticeshipMapper/WhenMappingLiveApprenticeshipWithAmbiguousWage.cs
+++ b/src/Esfa.Vacancy.UnitTests/GetApprenticeshipVacancy/Api/Mappings/GivenRaaApprenticeshipMapper/WhenMappingLiveApprenticeshipWithAmbiguousWage.cs
@@ -1,13 +1,13 @@
-﻿using ApiTypes = Esfa.Vacancy.Api.Types;
-using Esfa.Vacancy.Domain.Entities;
+﻿using Esfa.Vacancy.Domain.Entities;
 using Esfa.Vacancy.Domain.Interfaces;
-using Esfa.Vacancy.Infrastructure.Settings;
 using FluentAssertions;
 using Moq;
 using NUnit.Framework;
 using Ploeh.AutoFixture;
+using ApiTypes = Esfa.Vacancy.Api.Types;
+using ApprenticeshipVacancy = Esfa.Vacancy.Domain.Entities.ApprenticeshipVacancy;
 
-namespace Esfa.Vacancy.UnitTests.GetApprenticeshipVacancy.Api.Mappings.GivenAnApprenticeshipMapper
+namespace Esfa.Vacancy.UnitTests.GetApprenticeshipVacancy.Api.Mappings.GivenRaaApprenticeshipMapper
 {
     [TestFixture]
     public class WhenMappingLiveApprenticeshipWithAmbiguousWage
@@ -26,7 +26,7 @@ namespace Esfa.Vacancy.UnitTests.GetApprenticeshipVacancy.Api.Mappings.GivenAnAp
             var apprenticeshipVacancy = new Fixture().Build<ApprenticeshipVacancy>()
                 .With(v => v.VacancyReferenceNumber, vacancyReference)
                 .With(v => v.VacancyStatusId, liveVacancyStatusId)
-                .With(v => v.WageType, (int) legacyWageType)
+                .With(v => v.WageType, (int)legacyWageType)
                 .Without(v => v.WeeklyWage)
                 .Without(v => v.WageUnitId)
                 .Create();

--- a/src/Esfa.Vacancy.UnitTests/GetApprenticeshipVacancy/Api/Mappings/GivenRaaApprenticeshipMapper/WhenMappingLiveApprenticeshipWithApprenticeshipMinimumWageType.cs
+++ b/src/Esfa.Vacancy.UnitTests/GetApprenticeshipVacancy/Api/Mappings/GivenRaaApprenticeshipMapper/WhenMappingLiveApprenticeshipWithApprenticeshipMinimumWageType.cs
@@ -1,13 +1,13 @@
-﻿using ApiTypes = Esfa.Vacancy.Api.Types;
-using Esfa.Vacancy.Domain.Entities;
+﻿using Esfa.Vacancy.Domain.Entities;
 using Esfa.Vacancy.Domain.Interfaces;
-using Esfa.Vacancy.Infrastructure.Settings;
 using FluentAssertions;
 using Moq;
 using NUnit.Framework;
 using Ploeh.AutoFixture;
+using ApiTypes = Esfa.Vacancy.Api.Types;
+using ApprenticeshipVacancy = Esfa.Vacancy.Domain.Entities.ApprenticeshipVacancy;
 
-namespace Esfa.Vacancy.UnitTests.GetApprenticeshipVacancy.Api.Mappings.GivenAnApprenticeshipMapper
+namespace Esfa.Vacancy.UnitTests.GetApprenticeshipVacancy.Api.Mappings.GivenRaaApprenticeshipMapper
 {
     [TestFixture]
     [Parallelizable(ParallelScope.Fixtures)]

--- a/src/Esfa.Vacancy.UnitTests/GetApprenticeshipVacancy/Api/Mappings/GivenRaaApprenticeshipMapper/WhenMappingLiveApprenticeshipWithCustomRangeWageType.cs
+++ b/src/Esfa.Vacancy.UnitTests/GetApprenticeshipVacancy/Api/Mappings/GivenRaaApprenticeshipMapper/WhenMappingLiveApprenticeshipWithCustomRangeWageType.cs
@@ -1,13 +1,13 @@
-﻿using ApiTypes = Esfa.Vacancy.Api.Types;
-using Esfa.Vacancy.Domain.Entities;
+﻿using Esfa.Vacancy.Domain.Entities;
 using Esfa.Vacancy.Domain.Interfaces;
-using Esfa.Vacancy.Infrastructure.Settings;
 using FluentAssertions;
 using Moq;
 using NUnit.Framework;
 using Ploeh.AutoFixture;
+using ApiTypes = Esfa.Vacancy.Api.Types;
+using ApprenticeshipVacancy = Esfa.Vacancy.Domain.Entities.ApprenticeshipVacancy;
 
-namespace Esfa.Vacancy.UnitTests.GetApprenticeshipVacancy.Api.Mappings.GivenAnApprenticeshipMapper
+namespace Esfa.Vacancy.UnitTests.GetApprenticeshipVacancy.Api.Mappings.GivenRaaApprenticeshipMapper
 {
     [TestFixture]
     public class WhenMappingLiveApprenticeshipWithCustomRangeWageType

--- a/src/Esfa.Vacancy.UnitTests/GetApprenticeshipVacancy/Api/Mappings/GivenRaaApprenticeshipMapper/WhenMappingLiveApprenticeshipWithCustomWageType.cs
+++ b/src/Esfa.Vacancy.UnitTests/GetApprenticeshipVacancy/Api/Mappings/GivenRaaApprenticeshipMapper/WhenMappingLiveApprenticeshipWithCustomWageType.cs
@@ -1,13 +1,13 @@
-﻿using ApiTypes = Esfa.Vacancy.Api.Types;
-using Esfa.Vacancy.Domain.Entities;
+﻿using Esfa.Vacancy.Domain.Entities;
 using Esfa.Vacancy.Domain.Interfaces;
-using Esfa.Vacancy.Infrastructure.Settings;
 using FluentAssertions;
 using Moq;
 using NUnit.Framework;
 using Ploeh.AutoFixture;
+using ApiTypes = Esfa.Vacancy.Api.Types;
+using ApprenticeshipVacancy = Esfa.Vacancy.Domain.Entities.ApprenticeshipVacancy;
 
-namespace Esfa.Vacancy.UnitTests.GetApprenticeshipVacancy.Api.Mappings.GivenAnApprenticeshipMapper
+namespace Esfa.Vacancy.UnitTests.GetApprenticeshipVacancy.Api.Mappings.GivenRaaApprenticeshipMapper
 {
     [TestFixture]
     public class WhenMappingLiveApprenticeshipWithCustomWageType

--- a/src/Esfa.Vacancy.UnitTests/GetApprenticeshipVacancy/Api/Mappings/GivenRaaApprenticeshipMapper/WhenMappingLiveApprenticeshipWithLegacyTextWageType.cs
+++ b/src/Esfa.Vacancy.UnitTests/GetApprenticeshipVacancy/Api/Mappings/GivenRaaApprenticeshipMapper/WhenMappingLiveApprenticeshipWithLegacyTextWageType.cs
@@ -1,23 +1,23 @@
-﻿using ApiTypes = Esfa.Vacancy.Api.Types;
-using Esfa.Vacancy.Domain.Entities;
+﻿using Esfa.Vacancy.Domain.Entities;
 using Esfa.Vacancy.Domain.Interfaces;
-using Esfa.Vacancy.Infrastructure.Settings;
 using FluentAssertions;
 using Moq;
 using NUnit.Framework;
 using Ploeh.AutoFixture;
+using ApiTypes = Esfa.Vacancy.Api.Types;
+using ApprenticeshipVacancy = Esfa.Vacancy.Domain.Entities.ApprenticeshipVacancy;
 
-namespace Esfa.Vacancy.UnitTests.GetApprenticeshipVacancy.Api.Mappings.GivenAnApprenticeshipMapper
+namespace Esfa.Vacancy.UnitTests.GetApprenticeshipVacancy.Api.Mappings.GivenRaaApprenticeshipMapper
 {
     [TestFixture]
-    public class WhenMappingLiveApprenticeshipWithLegacyWeeklyWageType
+    public class WhenMappingLiveApprenticeshipWithLegacyTextWageType
     {
         [Test]
-        public void LiveVacanciesWithLegacyWeeklyWageTypeShouldHaveWageSetFromWeeklyWage()
+        public void ShouldHaveUnknownWageForVacanciesWithLegacyTextWageType()
         {
-            const int weeklyWage = 2550;
             const int vacancyReference = 1234;
             const int liveVacancyStatusId = 2;
+            const string unknownwWageText = "Unknown";
 
             var provideSettings = new Mock<IProvideSettings>();
             var sut = new Register.Api.Mappings.ApprenticeshipMapper(provideSettings.Object);
@@ -25,17 +25,15 @@ namespace Esfa.Vacancy.UnitTests.GetApprenticeshipVacancy.Api.Mappings.GivenAnAp
             var apprenticeshipVacancy = new Fixture().Build<ApprenticeshipVacancy>()
                 .With(v => v.VacancyReferenceNumber, vacancyReference)
                 .With(v => v.VacancyStatusId, liveVacancyStatusId)
-                .With(v => v.WageType, (int)LegacyWageType.LegacyWeekly)
-                .With(v => v.WeeklyWage, weeklyWage)
-                .Without(v => v.WageText)
-                .With(v => v.WageUnitId, 2)
+                .With(v => v.WageType, (int)LegacyWageType.LegacyText)
+                .Without(v => v.WageUnitId)
                 .Create();
 
             var vacancy = sut.MapToApprenticeshipVacancy(apprenticeshipVacancy);
 
             vacancy.VacancyReference.Should().Be(vacancyReference);
-            vacancy.WageUnit.Should().Be(ApiTypes.WageUnit.Weekly);
-            vacancy.WageText.Should().Be("£2,550.00");
+            vacancy.WageUnit.Should().Be(ApiTypes.WageUnit.Unspecified);
+            vacancy.WageText.Should().Be(unknownwWageText);
         }
     }
 }

--- a/src/Esfa.Vacancy.UnitTests/GetApprenticeshipVacancy/Api/Mappings/GivenRaaApprenticeshipMapper/WhenMappingLiveApprenticeshipWithLegacyWeeklyWageType.cs
+++ b/src/Esfa.Vacancy.UnitTests/GetApprenticeshipVacancy/Api/Mappings/GivenRaaApprenticeshipMapper/WhenMappingLiveApprenticeshipWithLegacyWeeklyWageType.cs
@@ -1,23 +1,23 @@
-﻿using ApiTypes = Esfa.Vacancy.Api.Types;
-using Esfa.Vacancy.Domain.Entities;
+﻿using Esfa.Vacancy.Domain.Entities;
 using Esfa.Vacancy.Domain.Interfaces;
-using Esfa.Vacancy.Infrastructure.Settings;
 using FluentAssertions;
 using Moq;
 using NUnit.Framework;
 using Ploeh.AutoFixture;
+using ApiTypes = Esfa.Vacancy.Api.Types;
+using ApprenticeshipVacancy = Esfa.Vacancy.Domain.Entities.ApprenticeshipVacancy;
 
-namespace Esfa.Vacancy.UnitTests.GetApprenticeshipVacancy.Api.Mappings.GivenAnApprenticeshipMapper
+namespace Esfa.Vacancy.UnitTests.GetApprenticeshipVacancy.Api.Mappings.GivenRaaApprenticeshipMapper
 {
     [TestFixture]
-    public class WhenMappingLiveApprenticeshipWithLegacyTextWageType
+    public class WhenMappingLiveApprenticeshipWithLegacyWeeklyWageType
     {
         [Test]
-        public void ShouldHaveUnknownWageForVacanciesWithLegacyTextWageType()
+        public void LiveVacanciesWithLegacyWeeklyWageTypeShouldHaveWageSetFromWeeklyWage()
         {
+            const int weeklyWage = 2550;
             const int vacancyReference = 1234;
             const int liveVacancyStatusId = 2;
-            const string unknownwWageText = "Unknown";
 
             var provideSettings = new Mock<IProvideSettings>();
             var sut = new Register.Api.Mappings.ApprenticeshipMapper(provideSettings.Object);
@@ -25,15 +25,17 @@ namespace Esfa.Vacancy.UnitTests.GetApprenticeshipVacancy.Api.Mappings.GivenAnAp
             var apprenticeshipVacancy = new Fixture().Build<ApprenticeshipVacancy>()
                 .With(v => v.VacancyReferenceNumber, vacancyReference)
                 .With(v => v.VacancyStatusId, liveVacancyStatusId)
-                .With(v => v.WageType, (int)LegacyWageType.LegacyText)
-                .Without(v => v.WageUnitId)
+                .With(v => v.WageType, (int)LegacyWageType.LegacyWeekly)
+                .With(v => v.WeeklyWage, weeklyWage)
+                .Without(v => v.WageText)
+                .With(v => v.WageUnitId, 2)
                 .Create();
 
             var vacancy = sut.MapToApprenticeshipVacancy(apprenticeshipVacancy);
 
             vacancy.VacancyReference.Should().Be(vacancyReference);
-            vacancy.WageUnit.Should().Be(ApiTypes.WageUnit.Unspecified);
-            vacancy.WageText.Should().Be(unknownwWageText);
+            vacancy.WageUnit.Should().Be(ApiTypes.WageUnit.Weekly);
+            vacancy.WageText.Should().Be("£2,550.00");
         }
     }
 }

--- a/src/Esfa.Vacancy.UnitTests/GetApprenticeshipVacancy/Api/Mappings/GivenRaaApprenticeshipMapper/WhenMappingLiveApprenticeshipWithNationalMinimumWageType.cs
+++ b/src/Esfa.Vacancy.UnitTests/GetApprenticeshipVacancy/Api/Mappings/GivenRaaApprenticeshipMapper/WhenMappingLiveApprenticeshipWithNationalMinimumWageType.cs
@@ -1,13 +1,13 @@
-﻿using ApiTypes = Esfa.Vacancy.Api.Types;
-using Esfa.Vacancy.Domain.Entities;
+﻿using Esfa.Vacancy.Domain.Entities;
 using Esfa.Vacancy.Domain.Interfaces;
-using Esfa.Vacancy.Infrastructure.Settings;
 using FluentAssertions;
 using Moq;
 using NUnit.Framework;
 using Ploeh.AutoFixture;
+using ApiTypes = Esfa.Vacancy.Api.Types;
+using ApprenticeshipVacancy = Esfa.Vacancy.Domain.Entities.ApprenticeshipVacancy;
 
-namespace Esfa.Vacancy.UnitTests.GetApprenticeshipVacancy.Api.Mappings.GivenAnApprenticeshipMapper
+namespace Esfa.Vacancy.UnitTests.GetApprenticeshipVacancy.Api.Mappings.GivenRaaApprenticeshipMapper
 {
     [TestFixture]
     [Parallelizable(ParallelScope.Fixtures)]

--- a/src/Esfa.Vacancy.UnitTests/GetApprenticeshipVacancy/Api/Mappings/GivenRaaApprenticeshipMapper/WhenMappingVacancyUrl.cs
+++ b/src/Esfa.Vacancy.UnitTests/GetApprenticeshipVacancy/Api/Mappings/GivenRaaApprenticeshipMapper/WhenMappingVacancyUrl.cs
@@ -1,0 +1,36 @@
+﻿using System.Threading.Tasks;
+using Esfa.Vacancy.Domain.Constants;
+using Esfa.Vacancy.Domain.Interfaces;
+using Esfa.Vacancy.Register.Api.Mappings;
+using Moq;
+using NUnit.Framework;
+using Ploeh.AutoFixture;
+
+namespace Esfa.Vacancy.UnitTests.GetApprenticeshipVacancy.Api.Mappings.GivenRaaApprenticeshipMapper
+{
+    public class WhenMappingVacancyUrl
+    {
+        [Test]
+        public async Task ShouldPopulateVacancyUrl()
+        {
+            //Arrange
+            var provideSettings = new Mock<IProvideSettings>();
+            var baseUrl = "https://findapprentice.com/apprenticeship/reference";
+            provideSettings
+                .Setup(p => p.GetSetting(ApplicationSettingKeys.LiveApprenticeshipVacancyBaseUrlKey))
+                .Returns(baseUrl);
+
+            var sut = new ApprenticeshipMapper(provideSettings.Object);
+
+            var vacancy = new Fixture().Build<Domain.Entities.ApprenticeshipVacancy>()
+                .With(v => v.WageUnitId, null)
+                .Create();
+
+            //Act
+            var result = sut.MapToApprenticeshipVacancy(vacancy);
+
+            //Assert
+            Assert.AreEqual($"{baseUrl}/{vacancy.VacancyReferenceNumber}", result.VacancyUrl);
+        }
+    }
+}

--- a/src/Esfa.Vacancy.UnitTests/GetApprenticeshipVacancy/Api/Mappings/GivenRaaApprenticeshipMapper/WhenMappingVacancyUrl.cs
+++ b/src/Esfa.Vacancy.UnitTests/GetApprenticeshipVacancy/Api/Mappings/GivenRaaApprenticeshipMapper/WhenMappingVacancyUrl.cs
@@ -1,5 +1,4 @@
-﻿using System.Threading.Tasks;
-using Esfa.Vacancy.Domain.Constants;
+﻿using Esfa.Vacancy.Domain.Constants;
 using Esfa.Vacancy.Domain.Interfaces;
 using Esfa.Vacancy.Register.Api.Mappings;
 using Moq;
@@ -8,10 +7,11 @@ using Ploeh.AutoFixture;
 
 namespace Esfa.Vacancy.UnitTests.GetApprenticeshipVacancy.Api.Mappings.GivenRaaApprenticeshipMapper
 {
+    [TestFixture]
     public class WhenMappingVacancyUrl
     {
         [Test]
-        public async Task ShouldPopulateVacancyUrl()
+        public void ShouldPopulateVacancyUrl()
         {
             //Arrange
             var provideSettings = new Mock<IProvideSettings>();

--- a/src/Esfa.Vacancy.UnitTests/GetApprenticeshipVacancy/Api/Mappings/GivenRecruitApprenticeshipMapper/RecruitApprenticeshipMapperBase.cs
+++ b/src/Esfa.Vacancy.UnitTests/GetApprenticeshipVacancy/Api/Mappings/GivenRecruitApprenticeshipMapper/RecruitApprenticeshipMapperBase.cs
@@ -1,0 +1,52 @@
+﻿using System;
+using Esfa.Vacancy.Application.Interfaces;
+using Esfa.Vacancy.Domain.Constants;
+using Esfa.Vacancy.Domain.Entities;
+using Esfa.Vacancy.Domain.Interfaces;
+using Esfa.Vacancy.Register.Api.Mappings;
+using Moq;
+using Ploeh.AutoFixture;
+using Ploeh.AutoFixture.AutoMoq;
+using SFA.DAS.Recruit.Vacancies.Client.Entities;
+
+namespace Esfa.Vacancy.UnitTests.GetApprenticeshipVacancy.Api.Mappings.GivenRecruitApprenticeshipMapper
+{
+    public abstract class RecruitApprenticeshipMapperBase
+    {
+        protected Mock<IProvideSettings> ProvideSettingsMock;
+        protected Mock<ITrainingDetailService> TrainingDetailServiceMock;
+        protected Mock<IGetMinimumWagesService> MinimumWageServiceMock;
+        protected IFixture FixtureInstance;
+        protected LiveVacancy LiveVacancy;
+
+        protected void Initialize()
+        {
+            FixtureInstance = new Fixture().Customize(new AutoMoqCustomization());
+
+            ProvideSettingsMock = FixtureInstance.Freeze<Mock<IProvideSettings>>();            
+
+            TrainingDetailServiceMock = FixtureInstance.Freeze<Mock<ITrainingDetailService>>();
+            TrainingDetailServiceMock.Setup(t => t.GetStandardDetailsAsync(It.IsAny<int>()))
+                .ReturnsAsync(FixtureInstance.Create<Standard>());
+
+            MinimumWageServiceMock = FixtureInstance.Freeze<Mock<IGetMinimumWagesService>>();
+            MinimumWageServiceMock.Setup(s => s.GetWageRangeAsync(It.IsAny<DateTime>()))
+                .ReturnsAsync(FixtureInstance.Create<WageRange>());
+
+            var wage = FixtureInstance.Build<Wage>()
+                .With(w => w.WageType, RecruitApprenticeshipMapper.FixedWageType)
+                .Create();
+            LiveVacancy = FixtureInstance.Build<LiveVacancy>()
+                .With(v => v.Wage, wage)
+                .With(v => v.ProgrammeType, "Standard")
+                .With(v => v.ProgrammeId, "123")
+                .Create();
+        }
+
+        protected internal RecruitApprenticeshipMapper GetRecruitApprecticeshipMapper()
+        {
+            return FixtureInstance.Create<RecruitApprenticeshipMapper>();
+        }
+
+    }
+}

--- a/src/Esfa.Vacancy.UnitTests/GetApprenticeshipVacancy/Api/Mappings/GivenRecruitApprenticeshipMapper/RecruitApprenticeshipMapperBase.cs
+++ b/src/Esfa.Vacancy.UnitTests/GetApprenticeshipVacancy/Api/Mappings/GivenRecruitApprenticeshipMapper/RecruitApprenticeshipMapperBase.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Globalization;
 using Esfa.Vacancy.Application.Interfaces;
 using Esfa.Vacancy.Domain.Constants;
 using Esfa.Vacancy.Domain.Entities;
@@ -48,5 +49,10 @@ namespace Esfa.Vacancy.UnitTests.GetApprenticeshipVacancy.Api.Mappings.GivenRecr
             return FixtureInstance.Create<RecruitApprenticeshipMapper>();
         }
 
+        protected string GetFormattedCurrencyString(decimal src)
+        {
+            const string currencyStringFormat = "C";
+            return src.ToString(currencyStringFormat, CultureInfo.GetCultureInfo("en-GB"));
+        }
     }
 }

--- a/src/Esfa.Vacancy.UnitTests/GetApprenticeshipVacancy/Api/Mappings/GivenRecruitApprenticeshipMapper/WhenMappingDuration.cs
+++ b/src/Esfa.Vacancy.UnitTests/GetApprenticeshipVacancy/Api/Mappings/GivenRecruitApprenticeshipMapper/WhenMappingDuration.cs
@@ -1,0 +1,33 @@
+﻿using FluentAssertions;
+using NUnit.Framework;
+using Ploeh.AutoFixture;
+using SFA.DAS.Recruit.Vacancies.Client.Entities;
+
+namespace Esfa.Vacancy.UnitTests.GetApprenticeshipVacancy.Api.Mappings.GivenRecruitApprenticeshipMapper
+{
+    [TestFixture]
+    public class WhenMappingDuration : RecruitApprenticeshipMapperBase
+    {
+        [SetUp]
+        public void Setup()
+        {
+            Initialize();
+        }
+
+        [TestCase(1, "Year", "1 Year", TestName = "And duration is one")]
+        [TestCase(2, "Year", "2 Years", TestName = "And duration is more than one")]
+        public void ThenMapDuration(int duration, string unit, string expectedOutput)
+        {
+            var sut = GetRecruitApprecticeshipMapper();
+            LiveVacancy.Wage = FixtureInstance.Build<Wage>()
+                .With(w => w.Duration, duration)
+                .With(w => w.DurationUnit, unit)
+                .Create();
+
+            var mappedVacancy = sut.MapFromRecruitVacancy(LiveVacancy).Result;
+
+            mappedVacancy.ExpectedDuration.Should().Be(expectedOutput);
+        }
+
+    }
+}

--- a/src/Esfa.Vacancy.UnitTests/GetApprenticeshipVacancy/Api/Mappings/GivenRecruitApprenticeshipMapper/WhenMappingFromLiveVacancy.cs
+++ b/src/Esfa.Vacancy.UnitTests/GetApprenticeshipVacancy/Api/Mappings/GivenRecruitApprenticeshipMapper/WhenMappingFromLiveVacancy.cs
@@ -1,0 +1,248 @@
+﻿using System;
+using System.Linq;
+using FluentAssertions;
+using NUnit.Framework;
+using NUnit.Framework.Internal;
+using ApiTypes = Esfa.Vacancy.Api.Types;
+
+namespace Esfa.Vacancy.UnitTests.GetApprenticeshipVacancy.Api.Mappings.GivenRecruitApprenticeshipMapper
+{
+    [TestFixture]
+    public class WhenMappingFromLiveVacancy : RecruitApprenticeshipMapperBase
+    {
+        private ApiTypes.ApprenticeshipVacancy _mappedVacancy;
+
+        [SetUp]
+        public void Setup()
+        {
+            Initialize();
+
+            var sut = GetRecruitApprecticeshipMapper();
+
+            _mappedVacancy = sut.MapFromRecruitVacancy(LiveVacancy).Result;
+        }
+
+        [Test]
+        public void ThenMapVacancyReference()
+        {
+            _mappedVacancy.VacancyReference.Should().Be(LiveVacancy.VacancyReference);
+        }
+
+        [Test]
+        public void ThenMapTitle()
+        {
+            _mappedVacancy.Title.Should().Be(LiveVacancy.Title);
+        }
+
+        [Test]
+        public void ThenMapShortDescription()
+        {
+            _mappedVacancy.ShortDescription.Should().Be(LiveVacancy.ShortDescription);
+        }
+
+        [Test]
+        public void ThenMapDescription()
+        {
+            var expectedValue = string.Concat(LiveVacancy.Description, Environment.NewLine,
+                LiveVacancy.TrainingDescription);
+            _mappedVacancy.Description.Should().Be(expectedValue);
+        }
+
+        [Test]
+        public void ThenMapWorkingWeek()
+        {
+            _mappedVacancy.WorkingWeek.Should().Be(LiveVacancy.Wage.WorkingWeekDescription);
+        }
+
+        [Test]
+        public void ThenMapWageAdditionalInformation()
+        {
+            _mappedVacancy.WageAdditionalInformation.Should().Be(LiveVacancy.Wage.WageAdditionalInformation);
+        }
+
+        [Test]
+        public void ThenMapWageHoursPerWeek()
+        {
+            _mappedVacancy.HoursPerWeek.Should().Be(LiveVacancy.Wage.WeeklyHours);
+        }
+
+        [Test]
+        public void ThenMapExpectedStartDate()
+        {
+            _mappedVacancy.ExpectedStartDate.Should().Be(LiveVacancy.StartDate);
+        }
+
+        [Test]
+        public void ThenMapPostedDate()
+        {
+            _mappedVacancy.PostedDate.Should().Be(LiveVacancy.LiveDate);
+        }
+
+        [Test]
+        public void ThenMapApplicationClosingDate()
+        {
+            _mappedVacancy.ApplicationClosingDate.Should().Be(LiveVacancy.ClosingDate);
+        }
+
+        [Test]
+        public void ThenMapNumberOfPositions()
+        {
+            _mappedVacancy.NumberOfPositions.Should().Be(LiveVacancy.NumberOfPositions);
+        }
+
+        [Test]
+        public void ThenMapEmployerName()
+        {
+            _mappedVacancy.EmployerName.Should().Be(LiveVacancy.EmployerName);
+        }
+
+        [Test]
+        public void ThenMapEmployerDescription()
+        {
+            _mappedVacancy.EmployerDescription.Should().Be(LiveVacancy.EmployerDescription);
+        }
+
+        [Test]
+        public void ThenMapEmployerWebsite()
+        {
+            _mappedVacancy.EmployerWebsite.Should().Be(LiveVacancy.EmployerWebsiteUrl);
+        }
+
+        [Test]
+        public void ThenMapContactName()
+        {
+            _mappedVacancy.ContactName.Should().Be(LiveVacancy.EmployerContactName);
+        }
+
+        [Test]
+        public void ThenMapContactEmail()
+        {
+            _mappedVacancy.ContactEmail.Should().Be(LiveVacancy.EmployerContactEmail);
+        }
+
+        [Test]
+        public void ThenMapContactNumber()
+        {
+            _mappedVacancy.ContactNumber.Should().Be(LiveVacancy.EmployerContactPhone);
+        }
+
+        [Test]
+        public void ThenMapTrainingToBeProvided()
+        {
+            _mappedVacancy.TrainingToBeProvided.Should().Be(LiveVacancy.TrainingDescription);
+        }
+
+        [Test]
+        public void ThenMapPersonalQualities()
+        {
+            _mappedVacancy.PersonalQualities.Should().BeNull();
+        }
+
+        [Test]
+        public void ThenMapImportantInformation()
+        {
+            _mappedVacancy.ImportantInformation.Should().BeNull();
+        }
+
+        [Test]
+        public void ThenMapApplicationInstructions()
+        {
+            _mappedVacancy.ApplicationInstructions.Should().Be(LiveVacancy.ApplicationInstructions);
+        }
+
+        [Test]
+        public void ThenMapApplicationUrl()
+        {
+            _mappedVacancy.ApplicationUrl.Should().Be(LiveVacancy.ApplicationUrl);
+        }
+
+        [Test]
+        public void ThenMapFutureProspects()
+        {
+            _mappedVacancy.FutureProspects.Should().Be(LiveVacancy.OutcomeDescription);
+        }
+
+        [Test]
+        public void ThenMapThingsToConsider()
+        {
+            _mappedVacancy.ThingsToConsider.Should().Be(LiveVacancy.ThingsToConsider);
+        }
+
+        [Test]
+        public void ThenMapIsNationwide()
+        {
+            _mappedVacancy.IsNationwide.Should().BeFalse();
+        }
+
+        [Test]
+        public void ThenMapSupplementaryQuestion1()
+        {
+            _mappedVacancy.SupplementaryQuestion1.Should().BeNull();
+        }
+
+        [Test]
+        public void ThenMapSupplementaryQuestion2()
+        {
+            _mappedVacancy.SupplementaryQuestion2.Should().BeNull();
+        }
+
+        [Test]
+        public void ThenMapTrainingProviderName()
+        {
+            _mappedVacancy.TrainingProviderName.Should().Be(LiveVacancy.TrainingProvider.Name);
+        }
+
+        [Test]
+        public void ThenMapTrainingProviderUkprn()
+        {
+            _mappedVacancy.TrainingProviderUkprn.Should().Be(LiveVacancy.TrainingProvider.Ukprn.ToString());
+        }
+
+        [Test]
+        public void ThenMapTrainingProviderSite()
+        {
+            _mappedVacancy.TrainingProviderSite.Should().BeNull();
+        }
+
+        [Test]
+        public void ThenMapIsEmployerDisabilityConfident()
+        {
+            _mappedVacancy.IsEmployerDisabilityConfident.Should().BeFalse();
+        }
+
+        [Test]
+        public void ThenMapApprenticeshipLevel()
+        {
+            _mappedVacancy.ApprenticeshipLevel.Should().Be(LiveVacancy.ProgrammeLevel);
+        }
+
+        [Test]
+        public void ThenMapLocation()
+        {
+            _mappedVacancy.Location.AddressLine1.Should().Be(LiveVacancy.EmployerLocation.AddressLine1);
+            _mappedVacancy.Location.AddressLine2.Should().Be(LiveVacancy.EmployerLocation.AddressLine2);
+            _mappedVacancy.Location.AddressLine3.Should().Be(LiveVacancy.EmployerLocation.AddressLine3);
+            _mappedVacancy.Location.AddressLine4.Should().Be(LiveVacancy.EmployerLocation.AddressLine4);
+            _mappedVacancy.Location.AddressLine5.Should().BeNull();
+            _mappedVacancy.Location.Town.Should().BeNull();
+            _mappedVacancy.Location.PostCode.Should().Be(LiveVacancy.EmployerLocation.Postcode);
+            _mappedVacancy.Location.GeoPoint.Latitude.Should().Be((decimal)LiveVacancy.EmployerLocation.Latitude);
+            _mappedVacancy.Location.GeoPoint.Longitude.Should().Be((decimal)LiveVacancy.EmployerLocation.Longitude);
+        }
+
+        [Test]
+        public void ThenMapSkillsRequired()
+        {
+            _mappedVacancy.SkillsRequired.Should().Be(string.Join(",", LiveVacancy.Skills));
+        }
+
+        [Test]
+        public void ThenMapQualificationsRequired()
+        {
+            var formattedDescriptions = LiveVacancy.Qualifications.Select(q => $"{q.QualificationType} {q.Subject} (Grade {q.Grade}) {q.Weighting}");
+            var output = string.Join(",", formattedDescriptions);
+
+            _mappedVacancy.QualificationsRequired.Should().Be(output);
+        }
+    }
+}

--- a/src/Esfa.Vacancy.UnitTests/GetApprenticeshipVacancy/Api/Mappings/GivenRecruitApprenticeshipMapper/WhenMappingTrainingCode.cs
+++ b/src/Esfa.Vacancy.UnitTests/GetApprenticeshipVacancy/Api/Mappings/GivenRecruitApprenticeshipMapper/WhenMappingTrainingCode.cs
@@ -1,0 +1,38 @@
+﻿using Esfa.Vacancy.Domain.Entities;
+using FluentAssertions;
+using Moq;
+using NUnit.Framework;
+using Ploeh.AutoFixture;
+
+namespace Esfa.Vacancy.UnitTests.GetApprenticeshipVacancy.Api.Mappings.GivenRecruitApprenticeshipMapper
+{
+    [TestFixture]
+    public class WhenMappingTrainingCode : RecruitApprenticeshipMapperBase
+    {
+        [SetUp]
+        public void Setup()
+        {
+            Initialize();
+        }
+
+        [TestCase("Standard", "123", "123")]
+        [TestCase("Framework", "111-2-33", "111")]
+        public void ThenMapTrainingCode(string trainingType, string trainingCode, string expectedOuput)
+        {
+            TrainingDetailServiceMock
+                .Setup(t => t.GetFrameworkDetailsAsync(It.IsAny<int>()))
+                .ReturnsAsync(FixtureInstance.Create<Framework>());
+            TrainingDetailServiceMock
+                .Setup(t => t.GetStandardDetailsAsync(It.IsAny<int>()))
+                .ReturnsAsync(FixtureInstance.Create<Standard>());
+
+            var sut = GetRecruitApprecticeshipMapper();
+            LiveVacancy.ProgrammeType = trainingType;
+            LiveVacancy.ProgrammeId = trainingCode;
+
+            var mappedVacancy = sut.MapFromRecruitVacancy(LiveVacancy).Result;
+
+            mappedVacancy.TrainingCode.Should().Be(expectedOuput);
+        }
+    }
+}

--- a/src/Esfa.Vacancy.UnitTests/GetApprenticeshipVacancy/Api/Mappings/GivenRecruitApprenticeshipMapper/WhenMappingTrainingTitle.cs
+++ b/src/Esfa.Vacancy.UnitTests/GetApprenticeshipVacancy/Api/Mappings/GivenRecruitApprenticeshipMapper/WhenMappingTrainingTitle.cs
@@ -1,0 +1,54 @@
+﻿using Esfa.Vacancy.Domain.Entities;
+using FluentAssertions;
+using Moq;
+using NUnit.Framework;
+using Ploeh.AutoFixture;
+
+namespace Esfa.Vacancy.UnitTests.GetApprenticeshipVacancy.Api.Mappings.GivenRecruitApprenticeshipMapper
+{
+    [TestFixture]
+    public class WhenMappingTrainingTitle : RecruitApprenticeshipMapperBase
+    {
+        [SetUp]
+        public void Setup()
+        {
+            Initialize();
+        }
+
+        [Test]
+        public void AndTrainingTypeIsStandard()
+        {
+            var standard = FixtureInstance.Create<Standard>();
+            TrainingDetailServiceMock
+                .Setup(t => t.GetStandardDetailsAsync(It.IsAny<int>()))
+                .ReturnsAsync(standard);
+
+            var sut = GetRecruitApprecticeshipMapper();
+            LiveVacancy.ProgrammeType = "Standard";
+
+            var mappedVacancy = sut.MapFromRecruitVacancy(LiveVacancy).Result;
+
+            mappedVacancy.TrainingTitle.Should().Be(standard.Title);
+
+            TrainingDetailServiceMock.Verify(t => t.GetFrameworkDetailsAsync(It.IsAny<int>()), Times.Never);
+        }
+
+        [Test]
+        public void AndTrainingTypeIsFramework()
+        {
+            var framework = FixtureInstance.Create<Framework>();
+            TrainingDetailServiceMock
+                .Setup(t => t.GetFrameworkDetailsAsync(It.IsAny<int>()))
+                .ReturnsAsync(framework);
+
+            var sut = GetRecruitApprecticeshipMapper();
+            LiveVacancy.ProgrammeType = "Framework";
+
+            var mappedVacancy = sut.MapFromRecruitVacancy(LiveVacancy).Result;
+
+            mappedVacancy.TrainingTitle.Should().Be(framework.Title);
+
+            TrainingDetailServiceMock.Verify(t => t.GetStandardDetailsAsync(It.IsAny<int>()), Times.Never);
+        }
+    }
+}

--- a/src/Esfa.Vacancy.UnitTests/GetApprenticeshipVacancy/Api/Mappings/GivenRecruitApprenticeshipMapper/WhenMappingTrainingType.cs
+++ b/src/Esfa.Vacancy.UnitTests/GetApprenticeshipVacancy/Api/Mappings/GivenRecruitApprenticeshipMapper/WhenMappingTrainingType.cs
@@ -1,0 +1,38 @@
+﻿using Esfa.Vacancy.Domain.Entities;
+using FluentAssertions;
+using Moq;
+using NUnit.Framework;
+using Ploeh.AutoFixture;
+using ApiTypes = Esfa.Vacancy.Api.Types;
+
+namespace Esfa.Vacancy.UnitTests.GetApprenticeshipVacancy.Api.Mappings.GivenRecruitApprenticeshipMapper
+{
+    [TestFixture]
+    public class WhenMappingTrainingType : RecruitApprenticeshipMapperBase
+    {
+        [SetUp]
+        public void Setup()
+        {
+            Initialize();
+        }
+
+        [TestCase("Standard", ApiTypes.TrainingType.Standard)]
+        [TestCase("Framework", ApiTypes.TrainingType.Framework)]
+        public void ThenMapTrainingType(string trainingType, ApiTypes.TrainingType expectedOuput)
+        {
+            TrainingDetailServiceMock
+                .Setup(t => t.GetFrameworkDetailsAsync(It.IsAny<int>()))
+                .ReturnsAsync(FixtureInstance.Create<Framework>());
+            TrainingDetailServiceMock
+                .Setup(t => t.GetStandardDetailsAsync(It.IsAny<int>()))
+                .ReturnsAsync(FixtureInstance.Create<Standard>());
+
+            var sut = GetRecruitApprecticeshipMapper();
+            LiveVacancy.ProgrammeType = trainingType;
+
+            var mappedVacancy = sut.MapFromRecruitVacancy(LiveVacancy).Result;
+
+            mappedVacancy.TrainingType.Should().Be(expectedOuput);
+        }
+    }
+}

--- a/src/Esfa.Vacancy.UnitTests/GetApprenticeshipVacancy/Api/Mappings/GivenRecruitApprenticeshipMapper/WhenMappingVacancyUrl.cs
+++ b/src/Esfa.Vacancy.UnitTests/GetApprenticeshipVacancy/Api/Mappings/GivenRecruitApprenticeshipMapper/WhenMappingVacancyUrl.cs
@@ -1,0 +1,31 @@
+﻿using Esfa.Vacancy.Domain.Constants;
+using FluentAssertions;
+using NUnit.Framework;
+using Ploeh.AutoFixture;
+
+namespace Esfa.Vacancy.UnitTests.GetApprenticeshipVacancy.Api.Mappings.GivenRecruitApprenticeshipMapper
+{
+    [TestFixture]
+    public class WhenMappingVacancyUrl : RecruitApprenticeshipMapperBase
+    {
+        [SetUp]
+        public void Setup()
+        {
+            Initialize();
+        }
+
+        [Test]
+        public void ThanMapVacancyUrl()
+        {
+            var baseUrl = FixtureInstance.Create<string>();
+            ProvideSettingsMock
+                .Setup(p => p.GetSetting(ApplicationSettingKeys.LiveApprenticeshipVacancyBaseUrlKey))
+                .Returns(baseUrl);
+            var sut = GetRecruitApprecticeshipMapper();
+
+            var mappedVacancy = sut.MapFromRecruitVacancy(LiveVacancy).Result;
+
+            mappedVacancy.VacancyUrl.Should().Be($"{baseUrl}/{LiveVacancy.VacancyReference}"); 
+        }
+    }
+}

--- a/src/Esfa.Vacancy.UnitTests/GetApprenticeshipVacancy/Api/Mappings/GivenRecruitApprenticeshipMapper/WhenMappingWageText.cs
+++ b/src/Esfa.Vacancy.UnitTests/GetApprenticeshipVacancy/Api/Mappings/GivenRecruitApprenticeshipMapper/WhenMappingWageText.cs
@@ -1,0 +1,101 @@
+﻿using System;
+using Esfa.Vacancy.Domain.Entities;
+using Esfa.Vacancy.Register.Api.Mappings;
+using FluentAssertions;
+using Moq;
+using NUnit.Framework;
+using Ploeh.AutoFixture;
+using SFA.DAS.Recruit.Vacancies.Client.Entities;
+
+namespace Esfa.Vacancy.UnitTests.GetApprenticeshipVacancy.Api.Mappings.GivenRecruitApprenticeshipMapper
+{
+    [TestFixture]
+    public class WhenMappingWageText : RecruitApprenticeshipMapperBase
+    {
+        [SetUp]
+        public void Setup()
+        {
+            Initialize();
+        }
+
+        [Test]
+        public void AndWageTypeIsFixedWage()
+        {
+            var sut = GetRecruitApprecticeshipMapper();
+            LiveVacancy.Wage = FixtureInstance.Build<Wage>()
+                .With(w => w.WageType, RecruitApprenticeshipMapper.FixedWageType)
+                .Create();
+
+            var mappedVacancy = sut.MapFromRecruitVacancy(LiveVacancy).Result;
+
+            mappedVacancy.WageText.Should().Be(LiveVacancy.Wage.FixedWageYearlyAmount.Value.ToString("C"));
+        }
+
+        [Test]
+        public void AndWageTypeIsUnspecified()
+        {
+            var sut = GetRecruitApprecticeshipMapper();
+            LiveVacancy.Wage = FixtureInstance.Build<Wage>()
+                .With(w => w.WageType, RecruitApprenticeshipMapper.UnspecifiedWageType)
+                .Create();
+
+            var mappedVacancy = sut.MapFromRecruitVacancy(LiveVacancy).Result;
+
+            mappedVacancy.WageText.Should().Be(RecruitApprenticeshipMapper.UnknownText);
+        }
+
+        [Test]
+        public void AndWageTypeIsNationalMinimumWage()
+        {
+            var minWage = 8m;
+            var maxWage = 10m;
+            var weeklyHours = 40;
+            var wageRange = FixtureInstance.Build<WageRange>()
+                .With(w => w.NationalMinimumWage, minWage)
+                .With(w => w.NationalMaximumWage, maxWage)
+                .Create();
+
+            MinimumWageServiceMock
+                .Setup(s => s.GetWageRangeAsync(It.IsAny<DateTime>()))
+                .ReturnsAsync(wageRange);
+
+            var sut = GetRecruitApprecticeshipMapper();
+            LiveVacancy.Wage = FixtureInstance.Build<Wage>()
+                .With(w => w.WageType, RecruitApprenticeshipMapper.NationalMinimumWageWageType)
+                .With(w => w.WeeklyHours, weeklyHours)
+                .Create();
+
+            var mappedVacancy = sut.MapFromRecruitVacancy(LiveVacancy).Result;
+
+            var expectedOutput = (minWage * weeklyHours).ToString("C") + " - " + (maxWage * weeklyHours).ToString("C");
+
+            mappedVacancy.WageText.Should().Be(expectedOutput);
+        }
+
+        [Test]
+        public void AndWageTypeIsNationalMinimumWageForApprentices()
+        {
+            var minWage = 8m;
+            var weeklyHours = 40;
+            var wageRange = FixtureInstance.Build<WageRange>()
+                .With(w => w.ApprenticeMinimumWage, minWage)
+                .Create();
+
+            MinimumWageServiceMock
+                .Setup(s => s.GetWageRangeAsync(It.IsAny<DateTime>()))
+                .ReturnsAsync(wageRange);
+
+            var sut = GetRecruitApprecticeshipMapper();
+            LiveVacancy.Wage = FixtureInstance.Build<Wage>()
+                .With(w => w.WageType, RecruitApprenticeshipMapper.NationalMinimumWageForApprenticesWageType)
+                .With(w => w.WeeklyHours, weeklyHours)
+                .Create();
+
+            var mappedVacancy = sut.MapFromRecruitVacancy(LiveVacancy).Result;
+
+            var expectedOutput = (minWage * weeklyHours).ToString("C");
+
+            mappedVacancy.WageText.Should().Be(expectedOutput);
+        }
+    }
+}

--- a/src/Esfa.Vacancy.UnitTests/GetApprenticeshipVacancy/Api/Mappings/GivenRecruitApprenticeshipMapper/WhenMappingWageText.cs
+++ b/src/Esfa.Vacancy.UnitTests/GetApprenticeshipVacancy/Api/Mappings/GivenRecruitApprenticeshipMapper/WhenMappingWageText.cs
@@ -28,7 +28,8 @@ namespace Esfa.Vacancy.UnitTests.GetApprenticeshipVacancy.Api.Mappings.GivenRecr
 
             var mappedVacancy = sut.MapFromRecruitVacancy(LiveVacancy).Result;
 
-            mappedVacancy.WageText.Should().Be(LiveVacancy.Wage.FixedWageYearlyAmount.Value.ToString("C"));
+            mappedVacancy.WageText.Should()
+                .Be(GetFormattedCurrencyString(LiveVacancy.Wage.FixedWageYearlyAmount.GetValueOrDefault()));
         }
 
         [Test]
@@ -67,7 +68,7 @@ namespace Esfa.Vacancy.UnitTests.GetApprenticeshipVacancy.Api.Mappings.GivenRecr
 
             var mappedVacancy = sut.MapFromRecruitVacancy(LiveVacancy).Result;
 
-            var expectedOutput = (minWage * weeklyHours).ToString("C") + " - " + (maxWage * weeklyHours).ToString("C");
+            var expectedOutput = GetFormattedCurrencyString(minWage * weeklyHours) + " - " + GetFormattedCurrencyString(maxWage * weeklyHours);
 
             mappedVacancy.WageText.Should().Be(expectedOutput);
         }
@@ -93,7 +94,7 @@ namespace Esfa.Vacancy.UnitTests.GetApprenticeshipVacancy.Api.Mappings.GivenRecr
 
             var mappedVacancy = sut.MapFromRecruitVacancy(LiveVacancy).Result;
 
-            var expectedOutput = (minWage * weeklyHours).ToString("C");
+            var expectedOutput = GetFormattedCurrencyString(minWage * weeklyHours);
 
             mappedVacancy.WageText.Should().Be(expectedOutput);
         }

--- a/src/Esfa.Vacancy.UnitTests/GetApprenticeshipVacancy/Api/Mappings/GivenRecruitApprenticeshipMapper/WhenMappingWageUnit.cs
+++ b/src/Esfa.Vacancy.UnitTests/GetApprenticeshipVacancy/Api/Mappings/GivenRecruitApprenticeshipMapper/WhenMappingWageUnit.cs
@@ -1,0 +1,33 @@
+﻿using Esfa.Vacancy.Register.Api.Mappings;
+using FluentAssertions;
+using NUnit.Framework;
+using Ploeh.AutoFixture;
+using SFA.DAS.Recruit.Vacancies.Client.Entities;
+using ApiTypes = Esfa.Vacancy.Api.Types;
+
+namespace Esfa.Vacancy.UnitTests.GetApprenticeshipVacancy.Api.Mappings.GivenRecruitApprenticeshipMapper
+{
+    [TestFixture]
+    public class WhenMappingWageUnit : RecruitApprenticeshipMapperBase
+    {
+        [SetUp]
+        public void Setup()
+        {
+            Initialize();
+        }
+
+        [TestCase(RecruitApprenticeshipMapper.FixedWageType, ApiTypes.WageUnit.Annually, TestName = "And wage type is custom then should be Yearly.")]
+        [TestCase("NationalMinimumWageForApprentices", ApiTypes.WageUnit.Weekly, TestName = "And wage type is custom then should be Yearly.")]
+        [TestCase("NationalMinimumWage", ApiTypes.WageUnit.Weekly, TestName = "And wage type is custom then should be Yearly.")]
+        [TestCase("Unspecified", ApiTypes.WageUnit.Unspecified, TestName = "And wage type is custom then should be Yearly.")]
+        public void ThenMapWageUnit(string wageType, ApiTypes.WageUnit wageUnit)
+        {
+            var sut = GetRecruitApprecticeshipMapper();
+            LiveVacancy.Wage = FixtureInstance.Build<Wage>().With(w => w.WageType, wageType).Create();
+
+            var mappedVacancy = sut.MapFromRecruitVacancy(LiveVacancy).Result;
+
+            mappedVacancy.WageUnit.Should().Be(wageUnit);
+        }
+    }
+}

--- a/src/Esfa.Vacancy.UnitTests/GetApprenticeshipVacancy/Api/Orchestrators/GivenAGetApprenticeshipVacancyOrchestrator/WhenGettingLiveApprenticeship.cs
+++ b/src/Esfa.Vacancy.UnitTests/GetApprenticeshipVacancy/Api/Orchestrators/GivenAGetApprenticeshipVacancyOrchestrator/WhenGettingLiveApprenticeship.cs
@@ -17,6 +17,7 @@ using Moq;
 using NUnit.Framework;
 using Ploeh.AutoFixture;
 using Ploeh.AutoFixture.AutoMoq;
+using SFA.DAS.Recruit.Vacancies.Client;
 
 namespace Esfa.Vacancy.UnitTests.GetApprenticeshipVacancy.Api.Orchestrators.GivenAGetApprenticeshipVacancyOrchestrator
 {
@@ -31,6 +32,7 @@ namespace Esfa.Vacancy.UnitTests.GetApprenticeshipVacancy.Api.Orchestrators.Give
         private IFixture _fixture;
         private string _expectedErrorMessage;
         private Mock<IValidationExceptionBuilder> _mockValidationExceptionBuilder;
+        private Mock<IClient> _mockClient;
 
         [SetUp]
         public void SetUp()
@@ -50,6 +52,8 @@ namespace Esfa.Vacancy.UnitTests.GetApprenticeshipVacancy.Api.Orchestrators.Give
                     new ValidationFailure("", _expectedErrorMessage)
                 }))
             ));
+
+            _mockClient = _fixture.Freeze<Mock<IClient>>();
 
             _sut = _fixture.Create<GetApprenticeshipVacancyOrchestrator>();
         }
@@ -85,7 +89,8 @@ namespace Esfa.Vacancy.UnitTests.GetApprenticeshipVacancy.Api.Orchestrators.Give
                                             .Create()
                 });
 
-            var sut = new GetApprenticeshipVacancyOrchestrator(_mockMediator.Object, _fixture.Create<ApprenticeshipMapper>(), _fixture.Create<IValidationExceptionBuilder>());
+            var sut = new GetApprenticeshipVacancyOrchestrator(_mockMediator.Object, _fixture.Create<ApprenticeshipMapper>(),
+                _fixture.Create<IValidationExceptionBuilder>(), _mockClient.Object);
             var result = await sut.GetApprenticeshipVacancyDetailsAsync(VacancyReference.ToString());
 
             result.VacancyReference.Should().Be(VacancyReference);
@@ -123,7 +128,8 @@ namespace Esfa.Vacancy.UnitTests.GetApprenticeshipVacancy.Api.Orchestrators.Give
                                             .Create()
                 });
 
-            var sut = new GetApprenticeshipVacancyOrchestrator(_mockMediator.Object, _fixture.Create<ApprenticeshipMapper>(), _fixture.Create<IValidationExceptionBuilder>());
+            var sut = new GetApprenticeshipVacancyOrchestrator(_mockMediator.Object, _fixture.Create<ApprenticeshipMapper>(),
+                _fixture.Create<IValidationExceptionBuilder>(), _mockClient.Object);
             var result = await sut.GetApprenticeshipVacancyDetailsAsync(VacancyReference.ToString());
 
             result.VacancyReference.Should().Be(VacancyReference);
@@ -136,7 +142,8 @@ namespace Esfa.Vacancy.UnitTests.GetApprenticeshipVacancy.Api.Orchestrators.Give
             result.Location.AddressLine4.Should().BeNull();
             result.Location.AddressLine5.Should().BeNull();
             result.Location.PostCode.Should().BeNull();
-            result.Location.GeoPoint.Should().BeNull();
+            result.Location.GeoPoint.Latitude.Should().BeNull();
+            result.Location.GeoPoint.Longitude.Should().BeNull();
             result.Location.Town.Should().NotBeNullOrWhiteSpace();
         }
 
@@ -163,7 +170,8 @@ namespace Esfa.Vacancy.UnitTests.GetApprenticeshipVacancy.Api.Orchestrators.Give
                 .Setup(m => m.Send(It.IsAny<GetApprenticeshipVacancyRequest>(), It.IsAny<CancellationToken>()))
                 .ReturnsAsync(response);
 
-            var sut = new GetApprenticeshipVacancyOrchestrator(_mockMediator.Object, new ApprenticeshipMapper(provideSettings.Object), _fixture.Create<IValidationExceptionBuilder>());
+            var sut = new GetApprenticeshipVacancyOrchestrator(_mockMediator.Object, new ApprenticeshipMapper(provideSettings.Object),
+                _fixture.Create<IValidationExceptionBuilder>(), _mockClient.Object);
 
             //Act
             var vacancy = await sut.GetApprenticeshipVacancyDetailsAsync("12345");

--- a/src/Esfa.Vacancy.UnitTests/GetApprenticeshipVacancy/Api/Orchestrators/GivenAGetApprenticeshipVacancyOrchestrator/WhenRecruitVacancyRequested.cs
+++ b/src/Esfa.Vacancy.UnitTests/GetApprenticeshipVacancy/Api/Orchestrators/GivenAGetApprenticeshipVacancyOrchestrator/WhenRecruitVacancyRequested.cs
@@ -21,6 +21,7 @@ namespace Esfa.Vacancy.UnitTests.GetApprenticeshipVacancy.Api.Orchestrators.Give
         private Mock<IMediator> _mockMediator;
         private Mock<IClient> _mockClient;
         private Mock<IApprenticeshipMapper> _mockMapper;
+        private Mock<IRecruitVacancyMapper> _recuitMapperMock;
 
         [SetUp]
         public void Initialise()
@@ -30,6 +31,7 @@ namespace Esfa.Vacancy.UnitTests.GetApprenticeshipVacancy.Api.Orchestrators.Give
             _mockMediator = fixture.Freeze<Mock<IMediator>>();
             _mockClient = fixture.Freeze<Mock<IClient>>();
             _mockMapper = fixture.Freeze<Mock<IApprenticeshipMapper>>();
+            _recuitMapperMock = fixture.Freeze<Mock<IRecruitVacancyMapper>>();
 
             var sut = fixture.Create<GetApprenticeshipVacancyOrchestrator>();
 
@@ -50,7 +52,7 @@ namespace Esfa.Vacancy.UnitTests.GetApprenticeshipVacancy.Api.Orchestrators.Give
         public void ThenRecruitClientIsInvoked()
         {
             _mockClient.Verify(m => m.GetVacancy(It.IsAny<long>()));
-            _mockMapper.Verify(m => m.MapFromRecruitVacancy(It.IsAny<LiveVacancy>()));
+            _recuitMapperMock.Verify(m => m.MapFromRecruitVacancy(It.IsAny<LiveVacancy>()));
         }
 
     }

--- a/src/Esfa.Vacancy.UnitTests/GetApprenticeshipVacancy/Api/Orchestrators/GivenAGetApprenticeshipVacancyOrchestrator/WhenRecruitVacancyRequested.cs
+++ b/src/Esfa.Vacancy.UnitTests/GetApprenticeshipVacancy/Api/Orchestrators/GivenAGetApprenticeshipVacancyOrchestrator/WhenRecruitVacancyRequested.cs
@@ -1,0 +1,57 @@
+﻿using System.Threading;
+using Esfa.Vacancy.Application.Queries.GetApprenticeshipVacancy;
+using Esfa.Vacancy.Domain.Entities;
+using Esfa.Vacancy.Register.Api.Mappings;
+using Esfa.Vacancy.Register.Api.Orchestrators;
+using MediatR;
+using Moq;
+using NUnit.Framework;
+using NUnit.Framework.Internal;
+using Ploeh.AutoFixture;
+using Ploeh.AutoFixture.AutoMoq;
+using SFA.DAS.Recruit.Vacancies.Client;
+using SFA.DAS.Recruit.Vacancies.Client.Entities;
+
+namespace Esfa.Vacancy.UnitTests.GetApprenticeshipVacancy.Api.Orchestrators.GivenAGetApprenticeshipVacancyOrchestrator
+{
+    [TestFixture]
+    public class WhenRecruitVacancyRequested
+    {
+        private GetApprenticeshipVacancyOrchestrator _sut;
+        private Mock<IMediator> _mockMediator;
+        private Mock<IClient> _mockClient;
+        private Mock<IApprenticeshipMapper> _mockMapper;
+
+        [SetUp]
+        public void Initialise()
+        {
+            var fixture = new Fixture().Customize(new AutoMoqCustomization());
+
+            _mockMediator = fixture.Freeze<Mock<IMediator>>();
+            _mockClient = fixture.Freeze<Mock<IClient>>();
+            _mockMapper = fixture.Freeze<Mock<IApprenticeshipMapper>>();
+
+            var sut = fixture.Create<GetApprenticeshipVacancyOrchestrator>();
+
+            sut.GetApprenticeshipVacancyDetailsAsync("1234567890").Wait();
+
+        }
+
+        [Test]
+        public void ThenMediatorIsNotInvoked()
+        {
+            _mockMediator
+                .Verify(m => m.Send(It.IsAny<GetApprenticeshipVacancyRequest>(), It.IsAny<CancellationToken>()), Times.Never);
+
+            _mockMapper.Verify(m => m.MapToApprenticeshipVacancy(It.IsAny<ApprenticeshipVacancy>()), Times.Never);
+        }
+
+        [Test]
+        public void ThenRecruitClientIsInvoked()
+        {
+            _mockClient.Verify(m => m.GetVacancy(It.IsAny<long>()));
+            _mockMapper.Verify(m => m.MapFromRecruitVacancy(It.IsAny<LiveVacancy>()));
+        }
+
+    }
+}

--- a/src/Esfa.Vacancy.UnitTests/GetApprenticeshipVacancy/Api/Orchestrators/GivenAGetApprenticeshipVacancyOrchestrator/WhenRecruitVacancyRequested.cs
+++ b/src/Esfa.Vacancy.UnitTests/GetApprenticeshipVacancy/Api/Orchestrators/GivenAGetApprenticeshipVacancyOrchestrator/WhenRecruitVacancyRequested.cs
@@ -17,7 +17,6 @@ namespace Esfa.Vacancy.UnitTests.GetApprenticeshipVacancy.Api.Orchestrators.Give
     [TestFixture]
     public class WhenRecruitVacancyRequested
     {
-        private GetApprenticeshipVacancyOrchestrator _sut;
         private Mock<IMediator> _mockMediator;
         private Mock<IClient> _mockClient;
         private Mock<IApprenticeshipMapper> _mockMapper;

--- a/src/Esfa.Vacancy.UnitTests/GetApprenticeshipVacancy/Application/Queries/GivenAGetApprenticeshipVacancyQueryHandler/WhenGettingApprenticeshipVacancy.cs
+++ b/src/Esfa.Vacancy.UnitTests/GetApprenticeshipVacancy/Application/Queries/GivenAGetApprenticeshipVacancyQueryHandler/WhenGettingApprenticeshipVacancy.cs
@@ -56,9 +56,9 @@ namespace Esfa.Vacancy.UnitTests.GetApprenticeshipVacancy.Application.Queries.Gi
         public async Task ThenIfVacancyHasFrameworkIdGetFrameworkTitle()
         {
             var vacancy = new ApprenticeshipVacancy() { FrameworkCode = 123 };
-           _mockValidator
-                .Setup(v => v.Validate(It.IsAny<ValidationContext<GetApprenticeshipVacancyRequest>>()))
-                .Returns(new ValidationResult());
+            _mockValidator
+                 .Setup(v => v.Validate(It.IsAny<ValidationContext<GetApprenticeshipVacancyRequest>>()))
+                 .Returns(new ValidationResult());
             _mockTrainingDetailService
                 .Setup(s => s.GetFrameworkDetailsAsync(It.IsAny<int>()))
                 .ReturnsAsync(new Framework() { Title = "framework" });
@@ -81,15 +81,15 @@ namespace Esfa.Vacancy.UnitTests.GetApprenticeshipVacancy.Application.Queries.Gi
                 .Setup(v => v.Validate(It.IsAny<ValidationContext<GetApprenticeshipVacancyRequest>>()))
                 .Returns(new ValidationResult());
             _mockTrainingDetailService
-                .Setup(s => s.GetAllStandardDetailsAsync())
-                .ReturnsAsync(new List<TrainingDetail> { new TrainingDetail { Title = "standard", TrainingCode = vacancy.StandardCode.ToString() } });
+                .Setup(s => s.GetStandardDetailsAsync(It.IsAny<int>()))
+                .ReturnsAsync(new Standard { Title = "standard", Code = vacancy.StandardCode.GetValueOrDefault() });
 
             _mockGetApprenticeshipService.Setup(r => r.GetApprenticeshipVacancyByReferenceNumberAsync(It.IsAny<int>())).ReturnsAsync(vacancy);
 
             var response = await _queryHandler.Handle(new GetApprenticeshipVacancyRequest());
 
             _mockTrainingDetailService.Verify(s => s.GetFrameworkDetailsAsync(It.IsAny<int>()), Times.Never);
-            _mockTrainingDetailService.Verify(s => s.GetAllStandardDetailsAsync());
+            _mockTrainingDetailService.Verify(s => s.GetStandardDetailsAsync(It.IsAny<int>()));
 
             Assert.AreEqual(vacancy, response.ApprenticeshipVacancy);
             Assert.IsNotNull(vacancy.Standard);

--- a/src/Esfa.Vacancy.UnitTests/GetTraineeshipVacancy/Api/Orchestrators/GivenAGetTraineeshipVacancyOrchestrator/WhenGettingLiveTraineeship.cs
+++ b/src/Esfa.Vacancy.UnitTests/GetTraineeshipVacancy/Api/Orchestrators/GivenAGetTraineeshipVacancyOrchestrator/WhenGettingLiveTraineeship.cs
@@ -134,7 +134,8 @@ namespace Esfa.Vacancy.UnitTests.GetTraineeshipVacancy.Api.Orchestrators.GivenAG
             result.Location.AddressLine4.Should().BeNull();
             result.Location.AddressLine5.Should().BeNull();
             result.Location.PostCode.Should().BeNull();
-            result.Location.GeoPoint.Should().BeNull();
+            result.Location.GeoPoint.Latitude.Should().BeNull();
+            result.Location.GeoPoint.Longitude.Should().BeNull();
             result.Location.Town.Should().NotBeNullOrWhiteSpace();
         }
 

--- a/src/Esfa.Vacancy.UnitTests/packages.config
+++ b/src/Esfa.Vacancy.UnitTests/packages.config
@@ -11,6 +11,7 @@
   <package id="Microsoft.AspNet.WebApi.Client" version="5.2.3" targetFramework="net452" />
   <package id="Microsoft.AspNet.WebApi.Core" version="5.2.3" targetFramework="net452" />
   <package id="Microsoft.AspNet.WebApi.WebHost" version="5.2.3" targetFramework="net452" />
+  <package id="mongocsharpdriver" version="1.10.0" targetFramework="net452" />
   <package id="Moq" version="4.7.63" targetFramework="net452" />
   <package id="NEST" version="1.9.2" targetFramework="net452" />
   <package id="Newtonsoft.Json" version="9.0.1" targetFramework="net452" />
@@ -19,6 +20,7 @@
   <package id="NUnit3TestAdapter" version="3.9.0" targetFramework="net452" />
   <package id="Polly" version="5.3.1" targetFramework="net452" />
   <package id="SFA.DAS.NLog.Logger" version="1.0.0.39208" targetFramework="net452" />
+  <package id="SFA.DAS.Recruit.Vacancies.Client" version="1.0.2" targetFramework="net452" />
   <package id="StructureMap" version="4.5.0" targetFramework="net452" />
   <package id="System.Reflection.Emit.Lightweight" version="4.3.0" targetFramework="net452" />
 </packages>


### PR DESCRIPTION
Apprenticeship Minimum wage services has been refactored to Minimum wage service so it can be used for national minimum as well. This requires a little bit of refactoring in V1 to make it consistent. Also I have copied some of the existing methods from existing Mapper in to Recruit mapper to keep it isolated. A tech debt task has been raised to normalise these properly. 