### PR TITLE
Add description when creating an API

### DIFF
--- a/src/Esfa.Vacancy.Azure.Resources/APIM/Import-APIMSwaggerApiDefinition.ps1
+++ b/src/Esfa.Vacancy.Azure.Resources/APIM/Import-APIMSwaggerApiDefinition.ps1
@@ -50,13 +50,13 @@ try {
 
         $apimuri = [System.Uri] $SwaggerSpecificationUrl
         if ($PSBoundParameters.ContainsKey("ApiUrlSuffix")) {
-            Write-Host "Creating API $ApiName with suffix $ApiUrlSuffix"
-            $newapi = New-AzureRmApiManagementApi -Context $Context -Name $ApiName -ServiceUrl "https://$($apimuri.Host)" -Protocols @("https") -Path $ApiUrlSuffix.ToLower()
+            $apisuf = $ApiUrlSuffix.ToLower()
         } else {
             $apisuf = $ApiName.Replace(' ','-').ToLower()
-            Write-Host "Creating API $ApiName with suffix $apisuf"
-            $newapi = New-AzureRmApiManagementApi -Context $Context -Name $ApiName -ServiceUrl "https://$($apimuri.Host)" -Protocols @("https") -Path $apisuf
         }
+
+        Write-Host "Creating API $ApiName with suffix $apisuf"
+        $newapi = New-AzureRmApiManagementApi -Context $Context -Name $ApiName -Description $ApiName -ServiceUrl "https://$($apimuri.Host)" -Protocols @("https") -Path $apisuf -ErrorAction Stop -Verbose:$VerbosePreference
         $ApiId = $newapi.ApiId
     }
 


### PR DESCRIPTION
Adds a description when creating an API inside the APIM. Please note this will be changed when the Swagger definition is imported to match that of the Swagger def info.description field